### PR TITLE
MODDICORE-51 "Mode of issuance" values not assigned correctly using marc-to-instance map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Reverted archive/unarchive eventPayload
 * [MODDICORE-42](https://issues.folio.org/browse/MODDICORE-42) Filtered out electronic access entries with missing uri values in mapped Instances
 * [MODDICORE-44](https://issues.folio.org/browse/MODDICORE-44) Null value if mapped field empty
+* [MODDICORE-51](https://issues.folio.org/browse/MODDICORE-51) "Mode of issuance" values not assigned correctly using marc-to-instance map in Fameflower
 
 ## 2020-04-03 v2.0.0
 * [MODDICORE-37](https://issues.folio.org/browse/MODDICORE-37) Added mechanism for archive/unarchive eventPayload

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -360,7 +360,7 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
     @Override
     public String apply(RuleExecutionContext context) {
       String subFieldValue = context.getSubFieldValue();
-      char seventhChar = subFieldValue.charAt(6); //Regarding "MODSOURMAN-203" is should be 7-th symbol.
+      char seventhChar = subFieldValue.charAt(7); //Regarding "MODSOURMAN-203" is should be 7-th symbol.
       List<IssuanceMode> issuanceModes = context.getMappingParameters().getIssuanceModes();
       if (issuanceModes == null || issuanceModes.isEmpty()) {
         return StringUtils.EMPTY;

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -657,10 +657,10 @@ public class NormalizationFunctionTest {
     String expectedIssuanceModeId = UUID.randomUUID().toString();
     IssuanceMode issuanceMode = new IssuanceMode()
       .withId(expectedIssuanceModeId)
-      .withName("serial");
+      .withName("integrating resource");
 
     RuleExecutionContext context = new RuleExecutionContext();
-    context.setSubFieldValue("aa ac bcdddmmmbsi");
+    context.setSubFieldValue("01743nai a2200409 i 450000");
     context.setMappingParameters(new MappingParameters().withIssuanceModes(Collections.singletonList(issuanceMode)));
     // when
     String actualIssuanceModeId = runFunction("set_issuance_mode_id", context);


### PR DESCRIPTION
Remember first byte of the Leader is 00, so byte 7 is actually the 8th position.

In the int_resource file, the leader is LDR 01743nai a2200409 i 4500, and we should be using the "i" in position 7 as the guide, which leads to mode of issuance = integrating resource