### PR TITLE
MODDICORE-61: Field mappings: Repeatable fields dropdown action without subfields support.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2020-06-05 v2.1.1-SNAPSHOT
+* [MODDICORE-61](https://issues.folio.org/browse/MODDICORE-61) Field mappings: Repeatable fields dropdown action without subfields support.
 * [MODDICORE-66](https://issues.folio.org/browse/MODDICORE-66) Mapping exception in mod-inventory with rules for notes - BUGFIX.
 * [MODDICORE-62](https://issues.folio.org/browse/MODDICORE-62) Adjusted handling of repeatable fields
 

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/MarcRecordReader.java
@@ -31,6 +31,7 @@ import java.text.ParseException;
 import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -102,6 +103,8 @@ public class MarcRecordReader implements Reader {
         return readSingleField(ruleExpression);
       } else if (!ruleExpression.getSubfields().isEmpty() && ruleExpression.getRepeatableFieldAction() != null) {
         return readRepeatableField(ruleExpression);
+      } else if (ruleExpression.getRepeatableFieldAction() == MappingRule.RepeatableFieldAction.DELETE_EXISTING) {
+        return RepeatableFieldValue.of(Collections.emptyList(), ruleExpression.getRepeatableFieldAction(), ruleExpression.getPath());
       }
     } catch (Exception e) {
       LOGGER.error("Error during reading MappingRule expressions ", e);

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -22,13 +22,16 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.DELETE_EXISTING;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.EXTEND_EXISTING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -421,6 +424,48 @@ public class MarcRecordReaderUnitTest {
     object2.put("instance.value", StringValue.of("test value"));
 
     assertEquals(JsonObject.mapFrom(RepeatableFieldValue.of(Arrays.asList(object1, object2), EXTEND_EXISTING, "instance")), JsonObject.mapFrom(value));
+  }
+
+  @Test
+  public void shouldReadRepeatableFieldsIfSubfieldsAreEmptyAndActionIsDeleteExisting() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD))).encode());
+    eventPayload.setContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload);
+
+    Value value = reader.read(new MappingRule()
+      .withPath("instance")
+      .withRepeatableFieldAction(DELETE_EXISTING)
+      .withSubfields(Collections.emptyList()));
+
+    assertNotNull(value);
+    assertEquals(ValueType.REPEATABLE, value.getType());
+    assertEquals("instance", ((RepeatableFieldValue) value).getRootPath());
+    assertEquals(DELETE_EXISTING, ((RepeatableFieldValue) value).getRepeatableFieldAction());
+
+    assertEquals(JsonObject.mapFrom(RepeatableFieldValue.of(emptyList(), DELETE_EXISTING, "instance")), JsonObject.mapFrom(value));
+  }
+
+  @Test
+  public void shouldReadRepeatableFieldsIfSubfieldsAreEmptyAndActionIsEmpty() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD))).encode());
+    eventPayload.setContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload);
+
+    Value value = reader.read(new MappingRule()
+      .withPath("instance")
+      .withRepeatableFieldAction(null)
+      .withSubfields(Collections.emptyList()));
+
+    assertNotNull(value);
+    assertEquals(ValueType.MISSING, value.getType());
   }
 
   @Test

--- a/src/test/java/org/folio/processing/mapping/writer/JsonBasedWriterUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/writer/JsonBasedWriterUnitTest.java
@@ -191,6 +191,25 @@ public class JsonBasedWriterUnitTest {
     assertEquals(expectedInstance, resultInstance);
   }
 
+  @Test
+  public void shouldWrite_RepeatableDeleteValuesIfSubfieldsAreEmpty() throws IOException {
+    // given
+    DataImportEventPayload eventContext = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(EntityType.INSTANCE.value(), "{\"contributor\":[{\"active\":true,\"id\":\"UUID2\",\"names\":[\"1\",\"2\",\"3\"]}]}");
+    eventContext.setContext(context);
+    // when
+    WRITER.initialize(eventContext);
+
+    RepeatableFieldValue field = RepeatableFieldValue.of(Collections.emptyList(), MappingRule.RepeatableFieldAction.DELETE_EXISTING, "contributor");
+    WRITER.write("contributor[]", field);
+
+    WRITER.getResult(eventContext);
+    // then
+    String resultInstance = eventContext.getContext().get(EntityType.INSTANCE.value());
+    assertEquals("{}", resultInstance);
+  }
+
 
   @Test
   public void shouldOverride_StringValue() throws IOException {


### PR DESCRIPTION
1.Added mechanism for passing DELETE_EXISTING action if subfields are empty in repeatable fields.
2. Tests added.
3. NEWS updated.