### PR TITLE
MODDICORE-116 - Support for invoice adjustments mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 * [MODDICORE-82](https://issues.folio.org/browse/MODDICORE-82) Change transport layer implementation to use Kafka
 * [MODDICORE-114](https://issues.folio.org/browse/MODDICORE-114) Add MARC-Instance default mappings for 880 fields.
 * [MODDSOURMAN-377](https://issues.folio.org/browse/MODSOURMAN-377) Update 5xx Notes mappings to indicate staff only for some notes.
+* [MODDICORE-115](https://issues.folio.org/browse/MODDICORE-115) Add implementation for EDIFACT reader
+* [MODDICORE-116](https://issues.folio.org/browse/MODDICORE-116) Support for invoice adjustments mapping
 
 ## 2020-11-20 v2.2.1
 * [MODDICORE-103](https://issues.folio.org/browse/MODDICORE-103) Fixed searching for next match profile

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/common/JsonBasedWriter.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/common/JsonBasedWriter.java
@@ -267,12 +267,12 @@ public class JsonBasedWriter extends AbstractWriter {
     }
 
     if (pathItem.isArray() && fieldValue.isArray()) {
-      ArrayNode arrayNode = (ArrayNode) parentNode.withArray(pathItem.getName());
+      ArrayNode arrayNode = parentNode.withArray(pathItem.getName());
       for (JsonNode jsonNode : fieldValue) {
         arrayNode.add(jsonNode);
       }
     } else if (pathItem.isArray() && fieldValue.isObject()) {
-      ArrayNode arrayNode = (ArrayNode) parentNode.withArray(pathItem.getName());
+      ArrayNode arrayNode = parentNode.withArray(pathItem.getName());
       arrayNode.add(fieldValue);
     } else if (pathItem.isObject() && !fieldValue.isArray()) {
       ((ObjectNode) parentNode).set(pathItem.getName(), fieldValue);

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/common/JsonBasedWriter.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/common/JsonBasedWriter.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.node.BooleanNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
 import org.folio.processing.mapping.mapper.writer.AbstractWriter;
@@ -31,6 +30,7 @@ import java.util.Map;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.logging.log4j.util.Strings.EMPTY;
+import static org.folio.processing.value.Value.ValueType.REPEATABLE;
 
 /**
  * A common Writer based on json. The idea is to hold Jackson's JsonNode and fill up it by incoming values in runtime.
@@ -110,18 +110,18 @@ public class JsonBasedWriter extends AbstractWriter {
     setValueByFieldPath(fieldPath, objectNode);
   }
 
-  private void writeValuesForRepeatableObject(JsonNode object, Map.Entry<String, Value> objectFields) {
+  private void writeValuesForRepeatableObject(JsonNode object, Map.Entry<String, Value> objectField) {
     JsonNode field = MissingNode.getInstance();
-    switch (objectFields.getValue().getType()) {
+    switch (objectField.getValue().getType()) {
       case LIST:
       case MAP:
-        field = objectMapper.valueToTree(objectFields.getValue().getValue());
+        field = objectMapper.valueToTree(objectField.getValue().getValue());
         break;
       case STRING:
-        field = new TextNode((String) objectFields.getValue().getValue());
+        field = new TextNode((String) objectField.getValue().getValue());
         break;
       case BOOLEAN:
-        BooleanValue bool = (BooleanValue) objectFields.getValue();
+        BooleanValue bool = (BooleanValue) objectField.getValue();
         MappingRule.BooleanFieldAction booleanFieldAction = bool.getValue();
         if (booleanFieldAction.equals(MappingRule.BooleanFieldAction.ALL_TRUE)) {
           field = BooleanNode.TRUE;
@@ -135,7 +135,7 @@ public class JsonBasedWriter extends AbstractWriter {
         break;
     }
     if (!field.isMissingNode()) {
-      setValueByFieldPath(objectFields.getKey().substring(objectFields.getKey().lastIndexOf('.') + 1), field, object);
+      setValueByFieldPath(objectField.getKey().substring(objectField.getKey().lastIndexOf('.') + 1), field, object);
     }
   }
 
@@ -173,10 +173,29 @@ public class JsonBasedWriter extends AbstractWriter {
     value.setAlreadyRemovedForExchange(false);
     for (Map<String, Value> subfield : repeatableFields) {
       JsonNode currentObject = objectMapper.createObjectNode();
-      for (Map.Entry<String, Value> objectFields : subfield.entrySet()) {
-        writeValuesForRepeatableObject(currentObject, objectFields);
+      for (Map.Entry<String, Value> objectField : subfield.entrySet()) {
+        if (objectField.getValue().getType().equals(REPEATABLE)) {
+          writeNestedRepeatableValue(objectField.getKey(), (RepeatableFieldValue) objectField.getValue(), currentObject);
+        } else {
+          writeValuesForRepeatableObject(currentObject, objectField);
+        }
       }
       setRepeatableValueByAction(value, repeatableFieldPath, currentObject);
+    }
+  }
+
+  private void writeNestedRepeatableValue(String repeatableFieldPath, RepeatableFieldValue value, JsonNode parentNode) {
+    List<Map<String, Value>> repeatableFields = value.getValue();
+    for (Map<String, Value> subfield : repeatableFields) {
+      JsonNode currentObject = objectMapper.createObjectNode();
+      for (Map.Entry<String, Value> objectField : subfield.entrySet()) {
+        if (objectField.getValue().getType().equals(REPEATABLE)) {
+          writeNestedRepeatableValue(objectField.getKey(), (RepeatableFieldValue) objectField.getValue(), currentObject);
+        } else {
+          writeValuesForRepeatableObject(currentObject, objectField);
+        }
+      }
+      setValueByFieldPath(repeatableFieldPath.substring(repeatableFieldPath.lastIndexOf('.') + 1), currentObject, parentNode);
     }
   }
 

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/JsonBasedWriterUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/JsonBasedWriterUnitTest.java
@@ -1,5 +1,7 @@
 package org.folio.processing.mapping.mapper.writer;
 
+import com.google.common.collect.Lists;
+import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
 import org.folio.processing.mapping.mapper.writer.common.JsonBasedWriter;
@@ -23,13 +25,13 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Arrays.asList;
+import static org.folio.rest.jaxrs.model.MappingRule.BooleanFieldAction.ALL_FALSE;
+import static org.folio.rest.jaxrs.model.MappingRule.BooleanFieldAction.ALL_TRUE;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.DELETE_EXISTING;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.DELETE_INCOMING;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.EXCHANGE_EXISTING;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.EXTEND_EXISTING;
 import static org.junit.Assert.assertEquals;
-
-import com.google.common.collect.Lists;
 
 @RunWith(JUnit4.class)
 public class JsonBasedWriterUnitTest {
@@ -82,7 +84,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -114,7 +116,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2")));
     object2.put("instance.contributor[].id", StringValue.of("UUID3"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -144,7 +146,7 @@ public class JsonBasedWriterUnitTest {
     object1.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_FALSE));
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2")));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -176,7 +178,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -209,7 +211,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -261,7 +263,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -294,7 +296,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2")));
     object2.put("instance.contributor[].id", StringValue.of("UUID3"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -326,7 +328,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -359,7 +361,7 @@ public class JsonBasedWriterUnitTest {
 
     object2.put("instance.contributor[].names[]", ListValue.of(asList("1", "2", "3")));
     object2.put("instance.contributor[].id", StringValue.of("UUID2"));
-    object2.put("instance.contributor[].active", BooleanValue.of(MappingRule.BooleanFieldAction.ALL_TRUE));
+    object2.put("instance.contributor[].active", BooleanValue.of(ALL_TRUE));
 
     objects.add(object1);
     objects.add(object2);
@@ -651,4 +653,51 @@ public class JsonBasedWriterUnitTest {
     String resultInstance = eventContext.getContext().get(EntityType.INSTANCE.value());
     assertEquals("{\"instance\":{\"title\":\"bla\"}}", resultInstance);
   }
+
+  @Test
+  public void shouldWriteNestedRepeatableFieldValue() throws IOException {
+    // given
+    DataImportEventPayload eventContext = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(EntityType.INVOICE.value(), "{}");
+    eventContext.setContext(context);
+
+    String rootPath = "invoice.adjustments[]";
+    String fundDistributionsRootPath = "invoice.adjustments[].fundDistributions[]";
+    Map<String, Value> fundDistributionElement1_1 = Map.of(
+      "invoice.adjustments[].fundDistributions[].fundId", StringValue.of("b2c0e100-0485-43f2-b161-3c60aac9f711"),
+      "invoice.adjustments[].fundDistributions[].code", StringValue.of("USHIST-1.1"));
+    Map<String, Value> fundDistributionElement1_2 = Map.of(
+      "invoice.adjustments[].fundDistributions[].fundId", StringValue.of("b2c0e100-0485-43f2-b161-3c60aac9f712"),
+      "invoice.adjustments[].fundDistributions[].code", StringValue.of("USHIST-1.2"));
+    Map<String, Value> fundDistributionElement2_1 = Map.of(
+      "invoice.adjustments[].fundDistributions[].fundId", StringValue.of("b2c0e100-0485-43f2-b161-3c60aac9f721"),
+      "invoice.adjustments[].fundDistributions[].code", StringValue.of("USHIST-2.1"));
+    Map<String, Value> fundDistributionElement2_2 = Map.of(
+      "invoice.adjustments[].fundDistributions[].fundId", StringValue.of("b2c0e100-0485-43f2-b161-3c60aac9f722"),
+      "invoice.adjustments[].fundDistributions[].code", StringValue.of("USHIST-2.2"));
+
+    Map<String, Value> adjustment1 = Map.of(
+      "invoice.adjustments[].description", StringValue.of("description-1"),
+      "invoice.adjustments[].exportToAccounting", BooleanValue.of(ALL_TRUE),
+      "invoice.adjustments[].fundDistributions[]", RepeatableFieldValue.of(List.of(fundDistributionElement1_1, fundDistributionElement1_2), EXTEND_EXISTING, fundDistributionsRootPath));
+    Map<String, Value> adjustment2 = Map.of(
+      "invoice.adjustments[].description", StringValue.of("description-2"),
+      "invoice.adjustments[].exportToAccounting", BooleanValue.of(ALL_FALSE),
+      "invoice.adjustments[].fundDistributions[]", RepeatableFieldValue.of(List.of(fundDistributionElement2_1, fundDistributionElement2_2), EXTEND_EXISTING, fundDistributionsRootPath));
+
+    RepeatableFieldValue value = RepeatableFieldValue.of(List.of(adjustment1, adjustment2), EXTEND_EXISTING, rootPath);
+
+    // when
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.INVOICE);
+    writer.initialize(eventContext);
+    writer.write(value.getRootPath(), value);
+    writer.getResult(eventContext);
+
+    // then
+    String expectedInvoiceAsString = "{\"invoice\":{\"adjustments\":[{\"fundDistributions\":[{\"code\":\"USHIST-1.1\",\"fundId\":\"b2c0e100-0485-43f2-b161-3c60aac9f711\"},{\"code\":\"USHIST-1.2\",\"fundId\":\"b2c0e100-0485-43f2-b161-3c60aac9f712\"}],\"exportToAccounting\":true,\"description\":\"description-1\"},{\"fundDistributions\":[{\"code\":\"USHIST-2.1\",\"fundId\":\"b2c0e100-0485-43f2-b161-3c60aac9f721\"},{\"code\":\"USHIST-2.2\",\"fundId\":\"b2c0e100-0485-43f2-b161-3c60aac9f722\"}],\"exportToAccounting\":false,\"description\":\"description-2\"}]}}";
+    String resultInvoice = eventContext.getContext().get(EntityType.INVOICE.value());
+    assertEquals(new JsonObject(expectedInvoiceAsString), new JsonObject(resultInvoice));
+  }
+
 }


### PR DESCRIPTION
## Purpose
To make able mapping invoice's "adjustments" and "fundDistributions" within them

## Approach

* expand `JsonBasedWriter` logic to support nested repeatable field values
* cover by test


## Learning
   * invoice schema: https://github.com/folio-org/acq-models/blob/master/mod-invoice-storage/schemas/invoice.json
   * adjustment schema: https://github.com/folio-org/acq-models/blob/ca1b0752b038f98cdb76ee5327772bc5f561385e/mod-invoice-storage/schemas/adjustment.json