### PR TITLE
MODSOURMAN-384: fix the operation queue for preparing the DI_ERROR event

### DIFF
--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -184,10 +184,10 @@ public final class EventManager {
   }
 
   private static DataImportEventPayload prepareErrorEventPayload(DataImportEventPayload eventPayload, Throwable throwable) {
-    eventPayload.setEventType(DI_ERROR.value());
     // an error occurred during handling of current event type, so it is pushed to the events chain
     eventPayload.getEventsChain().add(eventPayload.getEventType());
     eventPayload.getContext().put("ERROR", throwable.getMessage());
+    eventPayload.setEventType(DI_ERROR.value());
     return eventPayload;
   }
 


### PR DESCRIPTION
## Purpose
Improving DI_ERROR event for writing information to the log according MODINVSTOR-384

## Approach
Fixing the commands queue in the method for preparing DI_ERROR event

## Learning
[MODINVSTOR-384](https://issues.folio.org/browse/MODINVSTOR-384)