### PR TITLE
MODDICORE-127: Location code-Loan type assignment problems [BUGFIX]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-XX-XX v3.1.0-SNAPSHOT
+* [MODDICORE-127](https://issues.folio.org/browse/MODDICORE-127) Location code-Loan type assignment problems [BUGFIX]
+
 ## 2021-03-12 v3.0.0
 * [MODDICORE-82](https://issues.folio.org/browse/MODDICORE-82) Change transport layer implementation to use Kafka
 * [MODDICORE-114](https://issues.folio.org/browse/MODDICORE-114) Add MARC-Instance default mappings for 880 fields.


### PR DESCRIPTION
## Purpose
The main goal is to fix a bug related "permanentLocationId" for the holdings. There is "contains"-logic that can retrieve invalid location from mappingParameters, if there is a piece of the needed location-code.


## Approach
Contains logic was removed. But there is some complexity regarding this retrieving. 

For example, there is value from MARC-file, which indicates location code: "KU/CC/DI/M". 
And in mapping parameters (from inventory-storage) there will be this string: "Main Library (KU/CC/DI/M)".
So, simple "equals"-logic is invalid here. There should be retrieved specific code from brackets and after that, equals should be applied. Moreover, there can be a case when in MARC-file we will have this value: "(KU/CC/DI/M)" (with brackets). This case was covered too.

1. New mechanism for brackets was added.
2. Tests added.
3. News updated.

## Learning
More info: https://issues.folio.org/browse/MODDICORE-127
