### PR TITLE
MODDICORE-128: Holdings fails to create due to Location code not being recognized

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2021-XX-XX v3.0.1-SNAPSHOT
 * [MODDICORE-127](https://issues.folio.org/browse/MODDICORE-127) Location code-Loan type assignment problems [BUGFIX]
 * [MODSOURMAN-437](https://issues.folio.org/browse/MODSOURMAN-437) Add correlationId header to kafka record on publishing
+* [MODDICORE-128](https://issues.folio.org/browse/MODDICORE-128) Holdings fails to create due to Location code not being recognized.
 
 ## 2021-03-12 v3.0.0
 * [MODDICORE-82](https://issues.folio.org/browse/MODDICORE-82) Change transport layer implementation to use Kafka

--- a/src/main/java/org/folio/processing/mapping/MappingManager.java
+++ b/src/main/java/org/folio/processing/mapping/MappingManager.java
@@ -1,19 +1,24 @@
 package org.folio.processing.mapping;
 
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.DataImportEventPayload;
+import org.folio.Location;
 import org.folio.MappingProfile;
 import org.folio.processing.exceptions.MappingException;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.processing.mapping.mapper.FactoryRegistry;
 import org.folio.processing.mapping.mapper.Mapper;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.ReaderFactory;
 import org.folio.processing.mapping.mapper.writer.Writer;
 import org.folio.processing.mapping.mapper.writer.WriterFactory;
+import org.folio.rest.jaxrs.model.MappingRule;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
@@ -30,6 +35,9 @@ import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPP
 public final class MappingManager {
   private static final Logger LOGGER = LogManager.getLogger(MappingManager.class);
   private static final FactoryRegistry FACTORY_REGISTRY = new FactoryRegistry();
+  public static final String MAPPING_PARAMS = "MAPPING_PARAMS";
+  public static final String PERMANENT_LOCATION_ID = "permanentLocationId";
+  public static final String TEMPORARY_LOCATION_ID = "temporaryLocationId";
 
   private MappingManager() {
   }
@@ -49,12 +57,17 @@ public final class MappingManager {
         return eventPayload;
       }
       ProfileSnapshotWrapper mappingProfileWrapper = eventPayload.getCurrentNode();
+
       MappingProfile mappingProfile;
       if (mappingProfileWrapper.getContent() instanceof Map) {
         mappingProfile = new JsonObject((Map) mappingProfileWrapper.getContent()).mapTo(MappingProfile.class);
       } else {
         mappingProfile = (MappingProfile) mappingProfileWrapper.getContent();
       }
+
+      //Fix MODDICORE-128 (The system doesn't update acceptedLocation in mapping profiles after the location list is changed)
+      updateLocationsInMappingProfile(eventPayload, mappingProfile);
+
       Reader reader = FACTORY_REGISTRY.createReader(mappingProfile.getIncomingRecordType());
       Writer writer = FACTORY_REGISTRY.createWriter(mappingProfile.getExistingRecordType());
       return new Mapper() {
@@ -62,6 +75,37 @@ public final class MappingManager {
     } catch (Exception e) {
       throw new MappingException(e);
     }
+  }
+
+  /**
+   * Fill Permanent and Temporary Locations in MappingProfile from context MAPPING_PARAMS
+   *
+   * @param eventPayload - DataImportEventPayload
+   * @param mappingProfile - MappingProfile
+   */
+  private static void updateLocationsInMappingProfile(DataImportEventPayload eventPayload, MappingProfile mappingProfile) {
+    if ((mappingProfile.getMappingDetails() != null) && (mappingProfile.getMappingDetails().getMappingFields() != null)) {
+      HashMap<String, String> locations = getLocationsFromContextMappingParameters(eventPayload);
+      if (!locations.isEmpty()) {
+        for (MappingRule mappingRule : mappingProfile.getMappingDetails().getMappingFields()) {
+          if ((mappingRule.getName() != null) && (mappingRule.getName().equals(PERMANENT_LOCATION_ID) || mappingRule.getName().equals(TEMPORARY_LOCATION_ID))) {
+            mappingRule.setAcceptedValues(locations);
+          }
+        }
+      }
+    }
+  }
+
+  private static HashMap<String, String> getLocationsFromContextMappingParameters(DataImportEventPayload eventPayload) {
+    HashMap<String, String> locations = new HashMap<>();
+    String mappingParams = eventPayload.getContext().get(MAPPING_PARAMS);
+    if (StringUtils.isNotEmpty(mappingParams)) {
+      MappingParameters mappingParameters = new JsonObject(mappingParams).mapTo(MappingParameters.class);
+      for (Location location : mappingParameters.getLocations()) {
+        locations.put(location.getId(), location.getCode());
+      }
+    }
+    return locations;
   }
 
   /**


### PR DESCRIPTION
## Purpose
Holdings fails to create due to Location code not being recognized.

## Approach
Fill Permanent and Temporary Locations in MappingProfile from context MAPPING_PARAMS.

## Learning
[MODDICORE-128](https://issues.folio.org/browse/MODDICORE-128)
