### PR TITLE
MODDICORE-163 Use reliable apache commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>data-import-processing-core</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>data-import-processing-core</name>
   <organization>

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToInstanceMapper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToInstanceMapper.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.codehaus.plexus.util.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class MarcToInstanceMapper implements RecordToInstanceMapper {
 


### PR DESCRIPTION
While using data-import-processing-core as a dependency we were unable to map any records to instances that had a list in which used codehaus StringUtils isNotEmpty as a filter. It would just silently fail and hang. Occurred both on a Windows development machine and on infrastructure. 