### PR TITLE
MODDICORE-165: Data import matches to first possible location in list  instead of exact location.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-XX-XX v3.2.0-SNAPSHOT
 * [MODDICORE-159](https://issues.folio.org/browse/MODDICORE-159) Mode of issuance not updated when overlaying or updating record with existing SRS.
+* [MODDICORE-165](https://issues.folio.org/browse/MODDICORE-165)  Data import matches to first possible location in list  instead of exact location.
 
 ## 2021-06-11 v3.1.0
 * [MODSOURCE-279](https://issues.folio.org/browse/MODSOURCE-279) Store MARC Authority record

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -177,9 +177,9 @@ public class MarcRecordReader implements Reader {
 
   private boolean equalsBasedOnBrackets(String mappingParameter, String value) {
     if (mappingParameter.contains(FIRST_BRACKET) && mappingParameter.contains(SECOND_BRACKET)) {
-      if (retrieveStringFromBrackets(mappingParameter).equalsIgnoreCase(value)) {
+      if (retrieveStringFromLastBrackets(mappingParameter).equalsIgnoreCase(value)) {
         return true;
-      } else if (retrieveStringWithBrackets(mappingParameter).equalsIgnoreCase(value)) {
+      } else if (retrieveStringWithBracketsFromLastOne(mappingParameter).equalsIgnoreCase(value)) {
         return true;
       } else if (retrieveNameWithoutCode(mappingParameter).equalsIgnoreCase(value)) {
         return true;
@@ -189,11 +189,11 @@ public class MarcRecordReader implements Reader {
     return false;
   }
 
-  private String retrieveStringFromBrackets(String mappingParameter) {
-    return mappingParameter.substring(mappingParameter.indexOf(FIRST_BRACKET) + 1, mappingParameter.indexOf(SECOND_BRACKET));
+  private String retrieveStringFromLastBrackets(String mappingParameter) {
+    return mappingParameter.substring(mappingParameter.lastIndexOf(FIRST_BRACKET) + 1, mappingParameter.lastIndexOf(SECOND_BRACKET));
   }
 
-  private String retrieveStringWithBrackets(String mappingParameter) {
+  private String retrieveStringWithBracketsFromLastOne(String mappingParameter) {
     return mappingParameter.substring(mappingParameter.indexOf(FIRST_BRACKET), mappingParameter.indexOf(SECOND_BRACKET) + 1);
   }
 


### PR DESCRIPTION
## Purpose
There are cases when data import matches to the first possible location in the list instead of the exact location. The root cause of this issue is that there were created some universities with brackets inside location "name", not only "code"(For example: "Test Olin (Olin) (olin,ils)"). From the previous implementation, it retrieves from brackets value and compares it. That's why it matches with the invalid location. 

## Approach
1. There was added an improvement for retrieving value only from the last brackets (there will be always "code"-value)
2. Tests added.
3. NEWS.md updated.

## Learning
More info: https://issues.folio.org/browse/MODDICORE-165
