### PR TITLE
MODDICORE-166: Near the day boundary data import calculates today incorrectly.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2021-XX-XX v3.2.0-SNAPSHOT
 * [MODDICORE-159](https://issues.folio.org/browse/MODDICORE-159) Mode of issuance not updated when overlaying or updating record with existing SRS.
 * [MODDICORE-165](https://issues.folio.org/browse/MODDICORE-165)  Data import matches to first possible location in list  instead of exact location.
+* [MODDICORE-166](https://issues.folio.org/browse/MODDICORE-166)  Near the day boundary data import calculates today incorrectly.
 
 ## 2021-06-11 v3.1.0
 * [MODSOURCE-279](https://issues.folio.org/browse/MODSOURCE-279) Store MARC Authority record

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
@@ -61,6 +61,7 @@ public class MappingParameters {
   private List<Loantype> loanTypes = new ArrayList<>();
   private List<ItemNoteType> itemNoteTypes = new ArrayList<>();
   private List<MarcFieldProtectionSetting> marcFieldProtectionSettings = new ArrayList<>();
+  private String tenantConfiguration;
 
 
   public MappingParameters withInitializedState(boolean initialized) {
@@ -332,6 +333,14 @@ public class MappingParameters {
     return marcFieldProtectionSettings;
   }
 
+  public String getTenantConfiguration() {
+    return tenantConfiguration;
+  }
+
+  public void setTenantConfiguration(String tenantConfiguration) {
+    this.tenantConfiguration = tenantConfiguration;
+  }
+
   public void setMarcFieldProtectionSettings(List<MarcFieldProtectionSetting> marcFieldProtectionSettings) {
     this.marcFieldProtectionSettings = marcFieldProtectionSettings;
   }
@@ -393,6 +402,11 @@ public class MappingParameters {
 
   public MappingParameters withItemNoteTypes(List<ItemNoteType> itemNoteTypes) {
     this.itemNoteTypes = new UnmodifiableList<>(itemNoteTypes);
+    return this;
+  }
+
+  public MappingParameters withTenantConfiguration(String tenantConfiguration) {
+    this.tenantConfiguration = tenantConfiguration;
     return this;
   }
 

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -240,16 +240,10 @@ public class MarcRecordReader implements Reader {
         } else {
           tenantTimezone = new JsonObject(tenantConfiguration).getString(TIMEZONE_PROPERTY);
         }
-        String currentDateTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern(DATE_TIME_FORMAT));
-        LocalDateTime currentLocalDateTime = LocalDateTime.parse(currentDateTime, DateTimeFormatter.ofPattern(DATE_TIME_FORMAT));
-        ZoneId utcZoneId = ZoneId.of(UTC_TIMEZONE);
-        ZonedDateTime utcZonedDateTime = currentLocalDateTime.atZone(utcZoneId);
-
-        ZoneId currentZoneId = ZoneId.of(tenantTimezone);
-        ZonedDateTime currentZonedDateTime = utcZonedDateTime.withZoneSameInstant(currentZoneId); //convert time from UTC to tenant's timezone(if exists).
-        sb.append(isoFormatter.format(currentZonedDateTime));
+        ZonedDateTime utcZonedDateTime = ZonedDateTime.now(ZoneId.of(tenantTimezone));
+        sb.append(isoFormatter.format(utcZonedDateTime));
       } else {
-        sb.append(LocalDate.now().format(isoFormatter));
+        sb.append(LocalDate.now(ZoneId.of(UTC_TIMEZONE)).format(isoFormatter));
       }
     } catch (Exception e) {
       LOGGER.error("Can not process ##TODAY## expression", e);

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -675,7 +675,6 @@ public class MarcRecordReaderUnitTest {
     eventPayload.setContext(context);
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload);
-    String expectedDateString = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
 
     Value value = reader.read(new MappingRule()
       .withPath("")

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -644,7 +644,7 @@ public class MarcRecordReaderUnitTest {
     HashMap<String, String> context = new HashMap<>();
     context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
       .withParsedRecord(new ParsedRecord().withContent(RECORD))).encode());
-    context.put(MAPPING_PARAMS, "{\"initialized\":true,\"tenantConfiguration\":\"{\\\"locale\\\":\\\"en-US\\\",\\\"timezone\\\":\\\"Australia/Tasmania\\\",\\\"currency\\\":\\\"USD\\\"}\"}");
+    context.put(MAPPING_PARAMS, "{\"initialized\":true,\"tenantConfiguration\":\"{\\\"locale\\\":\\\"en-US\\\",\\\"timezone\\\":\\\"Pacific/Kiritimati\\\",\\\"currency\\\":\\\"USD\\\"}\"}");
     eventPayload.setContext(context);
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload);


### PR DESCRIPTION
## Purpose
When calculating ##TODAY## in a profile run at the end of the day, data import used the next day's date. Perhaps not using DST correctly. Observed on Cornell's tenant which is America/New York.

## Approach
Created brand new mechanism:

1. Retrieve tenant configuration from "/configurations/entries" in srm. There will be a current timezone for the tenant. (By default, it is empty, so it'll proceeded with UTC-timezone). Put this into MappingParameters to the dataImportEventPayload.
2. In di-core while processing ##TODAY##-expression retrieve from dataImportEventPayload current timezone for the tenant, calculate current dateTime in UTC(default) and convert to the timezone for the tenant.

## Learning
**This PR should be merged together with: https://github.com/folio-org/mod-source-record-manager/pull/458**
JIRA-ticket: https://issues.folio.org/browse/MODDICORE-166
