### PR TITLE
Modsource 340

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODDICORE-165](https://issues.folio.org/browse/MODDICORE-165)  Data import matches to first possible location in list  instead of exact location.
 * [MODDICORE-166](https://issues.folio.org/browse/MODDICORE-166)  Near the day boundary data import calculates today incorrectly.
 * [MODDICORE-171](https://issues.folio.org/browse/MODDICORE-171)  Add default mapping profile for MARC holdings
+* [MODSOURCE-340](https://issues.folio.org/browse/MODSOURCE-340)  Lower log level for messages when no handler found
 
 ## 2021-06-11 v3.1.0
 * [MODSOURCE-279](https://issues.folio.org/browse/MODSOURCE-279) Store MARC Authority record

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -44,7 +44,7 @@ public class EventProcessorImpl implements EventProcessor {
             }
           });
       } else {
-        LOG.warn("No suitable handler found for {} event type and current profile {}", eventPayload.getEventType(), eventPayload.getCurrentNode().getContentType());
+        LOG.info("No suitable handler found for {} event type and current profile {}", eventPayload.getEventType(), eventPayload.getCurrentNode().getContentType());
         future.completeExceptionally(new EventHandlerNotFoundException(format("No suitable handler found for %s event type", eventPayload.getEventType())));
       }
     } catch (Exception e) {


### PR DESCRIPTION
## Purpose
This is necessary to keep the mod-srs logs clean.
## Approach

- Lowering the logging level in EventProcessorImpl will display their mod-srs at the info level and will not interfere if the handler is not detected.

## Learning
https://issues.folio.org/browse/MODSOURCE-340