### PR TITLE
MODSOURMAN-563 Add MARC-Instance field mapping for Cancelled system control number

### DIFF
--- a/src/test/resources/org/folio/processing/mapping/instances.json
+++ b/src/test/resources/org/folio/processing/mapping/instances.json
@@ -196,6 +196,38 @@
         "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },
       {
+        "value": "(OCoLC)10110074",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)10244202",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)10783351",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)13815315",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)15380354",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)19554478",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)22099324",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
+        "value": "(OCoLC)22675561",
+        "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+      },
+      {
         "value": "(CStRLIN)NYCX83B57",
         "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
       },

--- a/src/test/resources/org/folio/processing/mapping/rules.json
+++ b/src/test/resources/org/folio/processing/mapping/rules.json
@@ -3880,9 +3880,9 @@
           "rules": [
             {
               "conditions": [
-              {
-                "type": "set_note_staff_only_via_indicator"
-              }
+                {
+                  "type": "set_note_staff_only_via_indicator"
+                }
               ]
             }
           ]
@@ -4559,30 +4559,30 @@
   ],
   "561": [
     {
-      "target": "notes.instanceNoteTypeId",
-      "description": "Instance note type id",
-      "subfield": [
-        "a",
-        "u",
-        "3",
-        "5"
-      ],
-      "applyRulesOnConcatenatedData": true,
-      "rules": [
+      "entity": [
         {
-          "conditions": [
+          "target": "notes.instanceNoteTypeId",
+          "description": "Instance note type id",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "applyRulesOnConcatenatedData": true,
+          "rules": [
             {
-              "type": "set_note_type_id",
-              "parameter": {
-                "name": "Ownership and Custodial History note"
-              }
+              "conditions": [
+                {
+                  "type": "set_note_type_id",
+                  "parameter": {
+                    "name": "Ownership and Custodial History note"
+                  }
+                }
+              ]
             }
           ]
-        }
-      ]
-    },
-    {
-      "entity": [
+        },
         {
           "target": "notes.note",
           "description": "Ownership and Custodial History",
@@ -5732,6 +5732,10 @@
       "target": "subjects",
       "description": "Subject Headings",
       "subfield": [
+        "a",
+        "c",
+        "d",
+        "g",
         "x",
         "y",
         "z",
@@ -5751,6 +5755,10 @@
         {
           "value": "--",
           "subfields": [
+            "a",
+            "c",
+            "d",
+            "g",
             "x",
             "y",
             "z",
@@ -6675,8 +6683,8 @@
       "subfield": [
         "6"
       ],
-      "fieldReplacementBy3Digits" : true,
-      "fieldReplacementRule" : [
+      "fieldReplacementBy3Digits": true,
+      "fieldReplacementRule": [
         {
           "sourceDigits": "100",
           "targetField": "700"

--- a/src/test/resources/org/folio/processing/mapping/rules.json
+++ b/src/test/resources/org/folio/processing/mapping/rules.json
@@ -113,6 +113,48 @@
       ]
     }
   ],
+  "019": [
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled system control number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Cancelled system control number",
+          "subfield": [
+            "a"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
   "020": [
     {
       "entity": [
@@ -463,6 +505,46 @@
           "description": "System Control Number",
           "subfield": [
             "a"
+          ]
+        }
+      ]
+    },
+    {
+      "entityPerRepeatedSubfield": true,
+      "entity": [
+        {
+          "target": "identifiers.identifierTypeId",
+          "description": "Type for Cancelled system control number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_identifier_type_id_by_name",
+                  "parameter": {
+                    "name": "Cancelled system control number"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "target": "identifiers.value",
+          "description": "Cancelled system control number",
+          "subfield": [
+            "z"
+          ],
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim"
+                }
+              ]
+            }
           ]
         }
       ]


### PR DESCRIPTION
In scope of adding Cancelled system control number as resource identifier type:

-	Updated mapping rules and instances to run tests for marc bibs with 019$a and 035$z subfields values;

https://issues.folio.org/browse/MODSOURMAN-563