### PR TITLE
MODDICORE-190. Incorrect mapping of acquisition ids causes validation issues and Invoices creating failures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-09-30 v3.3.0
+* [MODDICORE-190](https://issues.folio.org/browse/MODDICORE-190) Incorrect mapping of acquisition ids causes validation issues and Invoices creating failures
+
 ## 2021-09-29 v3.2.0
 * [MODDICORE-171](https://issues.folio.org/browse/MODDICORE-171) Add default mapping profile for MARC holdings
 * [MODDICORE-175](https://issues.folio.org/browse/MODDICORE-175) Ad Mapper for Holdings

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/edifact/EdifactRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/edifact/EdifactRecordReader.java
@@ -314,7 +314,7 @@ public class EdifactRecordReader implements Reader {
     for (RepeatableSubfieldMapping elementRule : mappingRule.getSubfields()) {
       for (MappingRule fieldRule : elementRule.getFields()) {
         if (StringUtils.isNotBlank(fieldRule.getValue())) {
-          values.add(readAcceptableValue(fieldRule));
+          values.add(readAcceptableValue(fieldRule, mappingRule.getAcceptedValues()));
         }
       }
     }
@@ -322,9 +322,13 @@ public class EdifactRecordReader implements Reader {
   }
 
   private String readAcceptableValue(MappingRule mappingRule) {
+    return readAcceptableValue(mappingRule, mappingRule.getAcceptedValues());
+  }
+
+  private String readAcceptableValue(MappingRule mappingRule, Map<String, String> acceptableValues) {
     String value = StringUtils.substringBetween(mappingRule.getValue(), QUOTATION_MARK);
-    if (MapUtils.isNotEmpty(mappingRule.getAcceptedValues())) {
-      for (Map.Entry<String, String> entry : mappingRule.getAcceptedValues().entrySet()) {
+    if (MapUtils.isNotEmpty(acceptableValues)) {
+      for (Map.Entry<String, String> entry : acceptableValues.entrySet()) {
         if (entry.getValue().equals(value)) {
           value = entry.getKey();
         }

--- a/src/test/java/org/folio/processing/mapping/reader/edifact/EdifactRecordReaderTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/edifact/EdifactRecordReaderTest.java
@@ -221,6 +221,7 @@ public class EdifactRecordReaderTest {
 
     MappingRule mappingRule = new MappingRule().withPath("invoice.acqUnitIds[]")
       .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+      .withAcceptedValues(acqUnitsAcceptedValues)
       .withSubfields(Arrays.asList(
         new RepeatableSubfieldMapping()
           .withOrder(0)
@@ -228,16 +229,14 @@ public class EdifactRecordReaderTest {
           .withFields(singletonList(
             new MappingRule()
               .withPath("invoice.acqUnitIds[]")
-              .withValue("\"ackUnit-1\"")
-              .withAcceptedValues(acqUnitsAcceptedValues))),
+              .withValue("\"ackUnit-1\""))),
         new RepeatableSubfieldMapping()
           .withOrder(1)
           .withPath("invoice.acqUnitIds[]")
           .withFields(singletonList(
             new MappingRule()
               .withPath("invoice.acqUnitIds[]")
-              .withValue("\"ackUnit-2\"")
-              .withAcceptedValues(acqUnitsAcceptedValues)))
+              .withValue("\"ackUnit-2\"")))
       ));
 
     Reader reader = readerFactory.createReader();


### PR DESCRIPTION
There is incorrect logic in data-import-processing with mapping acquisition units for invoices, instead of ids acquisition units names are mapped.

As particular example if we in debug mode(Pic. 1) - this method returns "main" instead of "0ebb1f7d-983f-3026-8a4c-5318e0ebc041" from acceptedValues array
![image](https://user-images.githubusercontent.com/25097693/136379951-048b6086-d42a-4ec6-8067-b9a79a648284.png)
Pic. 1 - In debug mode

This incorrect result value causes mod-invoice to fail validation during creating invoices and import fails in general 
![image](https://user-images.githubusercontent.com/25097693/136380165-179d4a96-e55d-4110-bebd-9254c2c44454.png)
