### PR TITLE
MODDICORE-216 Cannot edit a MARC Holdings record created with Add MARC Holdings record

### DIFF
--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -451,7 +451,7 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
       char sixthChar = subFieldValue.charAt(6);
       List<HoldingsType> holdingsTypes = context.getMappingParameters().getHoldingsTypes();
       if (holdingsTypes == null || holdingsTypes.isEmpty()) {
-        return STUB_FIELD_TYPE_ID;
+        return null;
       }
       String marcHoldingsType = HoldingsTypeEnum.getNameByCharacter(sixthChar);
       return findHoldingsTypeId(holdingsTypes, marcHoldingsType);

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunctionRunner.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunctionRunner.java
@@ -40,7 +40,7 @@ public class NormalizationFunctionRunner {
   public static String runFunction(String functionName, RuleExecutionContext ruleExecutionContext) {
     try {
       String result = NormalizationFunction.valueOf(functionName.trim().toUpperCase()).apply(ruleExecutionContext);
-      if(result.equals(StringUtils.EMPTY)){
+      if(result != null && result.equals(StringUtils.EMPTY)){
         LOGGER.debug("Result of {} function is empty", functionName);
       }
       return result;

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -763,7 +763,7 @@ public class NormalizationFunctionTest {
   }
 
   @Test
-  public void SET_HOLDINGS_TYPE_ID_shouldReturnEmptyStringIfMappingParametersEmpty() {
+  public void SET_HOLDINGS_TYPE_ID_shouldReturnNullStringIfMappingParametersEmpty() {
     RuleExecutionContext context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters());
     context.setSubFieldValue("00379cy  a22001334  4500");

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import static io.netty.util.internal.StringUtil.EMPTY_STRING;
 import static org.folio.processing.mapping.defaultmapper.processor.functions.NormalizationFunctionRunner.runFunction;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(JUnit4.class)
 public class NormalizationFunctionTest {
@@ -769,7 +770,7 @@ public class NormalizationFunctionTest {
     // when
     String holdingsTypeId = runFunction("set_holdings_type_id", context);
     // then
-    assertEquals(STUB_FIELD_TYPE_ID, holdingsTypeId);
+    assertNull(holdingsTypeId);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Return null instead of stub uuid for SET_HOLDINGS_TYPE_ID action

## Approach
- change verification in the SET_HOLDINGS_TYPE_ID 

## Learning
https://issues.folio.org/browse/MODDICORE-216
