### PR TITLE
MODDATAIMP-491: Improve logging to be able to trace the path of each record and file_chunks.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-xx-xx v3.3.0-SNAPSHOT
 * [MODDICORE-222](https://issues.folio.org/browse/MODDICORE-222) Authority: Add normalisation function to set note types
+* [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks
 
 ## 2021-09-30 v3.3.0
 * [MODDICORE-190](https://issues.folio.org/browse/MODDICORE-190) Incorrect mapping of acquisition ids causes validation issues and Invoices creating failures

--- a/src/test/java/org/folio/processing/events/services/publisher/KafkaEventPublisherTest.java
+++ b/src/test/java/org/folio/processing/events/services/publisher/KafkaEventPublisherTest.java
@@ -62,6 +62,7 @@ public class KafkaEventPublisherTest {
       .withToken(TOKEN)
       .withContext(new HashMap<>() {{
         put("recordId", UUID.randomUUID().toString());
+        put("chunkId", UUID.randomUUID().toString());
       }});
 
     CompletableFuture<Event> future = eventPublisher.publish(eventPayload);


### PR DESCRIPTION
## Purpose
 Improve logging to be able to trace the path of each record and file_chunks.

## Approach
_ChunkId added and put this to kafkaHeaders.


## Learning
https://issues.folio.org/browse/MODDATAIMP-491

