### PR TITLE
MODDICORE-228: mod-pubsub-client 2.4.0 fixing build failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pubsub.client.version>2.0.0</pubsub.client.version>
+    <pubsub.client.version>2.4.0</pubsub.client.version>
     <commons.lang.version>2.6</commons.lang.version>
     <logger.version>1.7.25</logger.version>
     <jackson.version>2.10.5.1</jackson.version>
@@ -99,6 +99,12 @@
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
       <version>${wiremock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.1.0</version>
       <scope>test</scope>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->

--- a/src/test/java/org/folio/processing/events/utils/PomReaderUtilTest.java
+++ b/src/test/java/org/folio/processing/events/utils/PomReaderUtilTest.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 import org.apache.maven.model.Dependency;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-import org.folio.rest.tools.PomReader;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +40,7 @@ class PomReaderUtilTest {
 
   @Test
   void testGetDependencies() {
-    List<Dependency> dependencies = PomReader.INSTANCE.getDependencies();
+    List<Dependency> dependencies = PomReaderUtil.INSTANCE.getDependencies();
     assertFalse(dependencies.isEmpty());
   }
 


### PR DESCRIPTION
Update mod-pubsub-client from 2.0.0 to 2.4.0 fixing
machine-in-the-middle (MITM) attack during build time (CVE-2021-26291).