### PR TITLE
MODDICORE-231 Data Import matches on identifier type and identifier value separately, resulting in incorrect matches (Kiwi BF)

### DIFF
--- a/src/main/java/org/folio/processing/matching/loader/query/LoadQueryBuilder.java
+++ b/src/main/java/org/folio/processing/matching/loader/query/LoadQueryBuilder.java
@@ -26,7 +26,8 @@ public class LoadQueryBuilder {
   private static final String JSON_PATH_SEPARATOR = ".";
   private static final String IDENTIFIER_TYPE_ID = "identifierTypeId";
   private static final String IDENTIFIER_TYPE_VALUE = "instance.identifiers[].value";
-  private static final String IDENTIFIER_CQL_QUERY = "(identifiers= /@value/@identifierTypeId=%s (%s))";
+  private static final String IDENTIFIER_CQL_QUERY = "identifiers =/@value/@identifierTypeId=\"%s\" %s";
+  private static final String WHERE_CLAUSE_CONSTRUCTOR_MATCH_CRITERION = "WHERE_CLAUSE_CONSTRUCTOR";
 
   /**
    * Builds LoadQuery,
@@ -60,7 +61,10 @@ public class LoadQueryBuilder {
             mainQuery.applyAdditionalCondition(additionalQuery);
             // TODO provide all the requirements for MODDATAIMP-592 and refactor code block below
             if(checkIfIdentifierTypeExists(matchDetail, fieldPath, additionalField.getLabel())) {
-              mainQuery.setCqlQuery(String.format(IDENTIFIER_CQL_QUERY, additionalField.getValue(), value.getValue().toString()));
+              MatchingCondition matchingCondition =
+                MatchingCondition.valueOf(WHERE_CLAUSE_CONSTRUCTOR_MATCH_CRITERION);
+              String condition = matchingCondition.constructCqlQuery(value);
+              mainQuery.setCqlQuery(String.format(IDENTIFIER_CQL_QUERY, additionalField.getValue(), condition));
               mainQuery.setSqlQuery(StringUtils.EMPTY);
             }
           }

--- a/src/main/java/org/folio/processing/matching/loader/query/MatchingCondition.java
+++ b/src/main/java/org/folio/processing/matching/loader/query/MatchingCondition.java
@@ -35,7 +35,8 @@ public enum MatchingCondition {
   EXISTING_VALUE_BEGINS_WITH_INCOMING_VALUE("FIELD_NAME LIKE '%s%%'",
     "FIELD_NAME == \"%s*\""),
   INCOMING_VALUE_BEGINS_WITH_EXISTING_VALUE("'%s' LIKE CONCAT(FIELD_NAME, '%%')",
-    EMPTY);
+    EMPTY),
+  WHERE_CLAUSE_CONSTRUCTOR("\"%s\"", "\"%s\"");
 
   private String sqlCondition;
   private String cqlQuery;

--- a/src/test/java/org/folio/processing/matching/loader/LoadQueryBuilderTest.java
+++ b/src/test/java/org/folio/processing/matching/loader/LoadQueryBuilderTest.java
@@ -15,7 +15,6 @@ import org.folio.rest.jaxrs.model.Qualifier;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MatchExpression;
 import org.folio.rest.jaxrs.model.StaticValueDetails;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -692,7 +691,7 @@ public class LoadQueryBuilderTest {
     assertNotEquals(expectedSQLQuery, wrongResult.getSql());
     assertNotNull(result.getCql());
     assertNotNull(wrongResult.getCql());
-    String expectedCQLQuery = format("(identifiers= /@value/@identifierTypeId=%s (%s))",identifierTypeFieldValue, value.getValue());
+    String expectedCQLQuery = format("identifiers =/@value/@identifierTypeId=\"%s\" \"%s\"",identifierTypeFieldValue, value.getValue());
     assertEquals(expectedCQLQuery, result.getCql());
     assertNotEquals(expectedCQLQuery, wrongResult.getCql());
   }


### PR DESCRIPTION
## Purpose
Fix construct cql queries for identifier when change "exactly matches" matching criteria.

## Approach

- Finding entry into the query holder identifier with matching criteria "exactly matches"
- Seting cqlQuery in new format 
**/inventory/instances?query=(identifiers= /@value/@identifierTypeId=8261054f-be78-422d-bd51-4ed9f33c3422 (785633))** instead of 
**{{baseUrl}}/inventory/instances?query=identifiers=""\""identifierTypeId\"":\""8261054f-be78-422d-bd51-4ed9f33c342\"""" AND (identifiers=""\""value\"":\""785633\"""")**
for an accurate search inside the array

## Learning
https://issues.folio.org/browse/MODDICORE-231
Meets the requirements of the first two requirements, the third was added after the start of work on the task