### PR TITLE
MODDICORE-242 MARC 007 is retained although overlay does not contain MARC 007 field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx
+* [MODDICORE-242](https://issues.folio.org/browse/MODDICORE-242) MARC 007 is retained although overlay does not contain MARC 007 field
+
 ## 2021-12-21 v3.2.7
 * Fix log4j vulnerability (upgrade to folio-kafka-wrapper v2.4.2)
 

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -555,6 +555,7 @@ public class MarcRecordModifier {
         replaceDataField(dataField, dataField.getTag(), dataField.getIndicator1(), dataField.getIndicator2(), "*");
       }
     }
+    clearUnUpdatedControlFields();
     clearUnUpdatedDataFields();
   }
 
@@ -625,6 +626,18 @@ public class MarcRecordModifier {
     }
   }
 
+  private void clearUnUpdatedControlFields() {
+    List<ControlField> tmpFields = new ArrayList<>();
+    for (ControlField controlField : marcRecordToChange.getControlFields()) {
+      if (!isControlFieldsContains(incomingMarcRecord.getControlFields(), controlField)
+        && !isNonRepeatableField(controlField)
+        && isNotProtected(controlField)) {
+        tmpFields.add(controlField);
+      }
+    }
+    marcRecordToChange.getControlFields().removeAll(tmpFields);
+  }
+
   private void clearUnUpdatedDataFields() {
     List<DataField> tmpFields = new ArrayList<>();
     for (DataField dataField : marcRecordToChange.getDataFields()) {
@@ -667,4 +680,9 @@ public class MarcRecordModifier {
       .collect(Collectors.toList());
   }
 
+  private boolean isControlFieldsContains(List<ControlField> controlFields, ControlField controlField) {
+    return controlFields.stream().anyMatch(field ->
+      field.getTag().equals(controlField.getTag())
+        && field.getData().equals(controlField.getData()));
+  }
 }


### PR DESCRIPTION
### Learning: 
[MODDICORE-242](https://issues.folio.org/browse/MODDICORE-242)

### Approach
- Remove unUpdated repeatable controlFields