### PR TITLE
MODDICORE-252: Data Import Update SRS duplicates protected fields on update when there is more than one of any given tag.

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -20,8 +20,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Range;
 import org.apache.commons.lang3.StringUtils;
@@ -676,7 +678,7 @@ public class MarcRecordModifier {
       dataFields.removeAll(tmpFields);
     }
 
-    if (ifNewDataShouldBeAdded) {
+    if (ifNewDataShouldBeAdded && isNotProtected(fieldReplacement)) {
       updatedFields.add(fieldReplacement);
       addDataFieldInNumericalOrder(fieldReplacement);
     }


### PR DESCRIPTION
**Overview**
The main issue was that if there are some fields with the same subfield, code, and tag, and if this field is protected - then it will appear twice(duplicated).
**Approach**
 Additional condition added. 
