### PR TITLE
MODINV-671. Check and fix the sending of DI_ERROR after DuplicateEventException appears

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx v3.4.0-SNAPSHOT
+* [MODINV-671](https://issues.folio.org/browse/MODINV-671) Check and fix the sending of DI_ERROR after DuplicateEventException appears
+
 ## 2021-02-22 v3.3.0
 * [MODDICORE-222](https://issues.folio.org/browse/MODDICORE-222) Authority: Add normalisation function to set note types
 * [MODDATAIMP-491](https://issues.folio.org/browse/MODDATAIMP-491) Improve logging to be able to trace the path of each record and file_chunks

--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
@@ -92,7 +93,8 @@ public final class EventManager {
   }
 
   private static CompletableFuture<Boolean> publishEventIfNecessary(DataImportEventPayload eventPayload, ProfileSnapshotWrapper jobProfileSnapshot, Throwable processThrowable) {
-    if (processThrowable instanceof EventHandlerNotFoundException || processThrowable.getCause() instanceof DuplicateEventException) {
+    if (processThrowable instanceof EventHandlerNotFoundException ||
+      (Objects.nonNull(processThrowable) && processThrowable.getCause() instanceof DuplicateEventException)) {
       return CompletableFuture.completedFuture(false);
     }
     return eventPublisher.get(0).publish(prepareEventPayload(eventPayload, jobProfileSnapshot, processThrowable))

--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -92,7 +92,7 @@ public final class EventManager {
   }
 
   private static CompletableFuture<Boolean> publishEventIfNecessary(DataImportEventPayload eventPayload, ProfileSnapshotWrapper jobProfileSnapshot, Throwable processThrowable) {
-    if (processThrowable instanceof EventHandlerNotFoundException || processThrowable instanceof DuplicateEventException) {
+    if (processThrowable instanceof EventHandlerNotFoundException || processThrowable.getCause() instanceof DuplicateEventException) {
       return CompletableFuture.completedFuture(false);
     }
     return eventPublisher.get(0).publish(prepareEventPayload(eventPayload, jobProfileSnapshot, processThrowable))


### PR DESCRIPTION
Mod-inventory wraps DuplicateEventException into CompletionException, so we need to change data-import-processing-core to check cause instead. Details on the screen below:
![image](https://user-images.githubusercontent.com/25097693/161016546-60ea53fb-d3db-4e21-a087-919148c92188.png)

For EventHandlerNotFound we don't need such changes because this exception throwing without any wrapping like this:
![image](https://user-images.githubusercontent.com/25097693/161019079-db590322-77b5-4c6e-b995-f240700d51dd.png)
