### PR TITLE
MODDICORE-264 Support correlationId header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2022-xx-xx v3.4.0-SNAPSHOT
 * [MODINV-671](https://issues.folio.org/browse/MODINV-671) Check and fix the sending of DI_ERROR after DuplicateEventException appears
+* [MODDICORE-264](https://issues.folio.org/browse/MODDICORE-264) Support correlationId header
 
 ## 2021-02-22 v3.3.0
 * [MODDICORE-222](https://issues.folio.org/browse/MODDICORE-222) Authority: Add normalisation function to set note types

--- a/src/main/java/org/folio/processing/events/services/publisher/KafkaEventPublisher.java
+++ b/src/main/java/org/folio/processing/events/services/publisher/KafkaEventPublisher.java
@@ -1,5 +1,7 @@
 package org.folio.processing.events.services.publisher;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TENANT_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_TOKEN_HEADER;
 import static org.folio.rest.util.OkapiConnectionParams.OKAPI_URL_HEADER;
@@ -83,7 +85,9 @@ public class KafkaEventPublisher implements EventPublisher {
       headers.add(KafkaHeader.header(OKAPI_URL_HEADER, eventPayload.getOkapiUrl()));
       headers.add(KafkaHeader.header(OKAPI_TENANT_HEADER, eventPayload.getTenant()));
       headers.add(KafkaHeader.header(OKAPI_TOKEN_HEADER, eventPayload.getToken()));
-      headers.add(KafkaHeader.header(CORRELATION_ID_HEADER, correlationId));
+      if (isNotBlank(correlationId)) {
+        headers.add(KafkaHeader.header(CORRELATION_ID_HEADER, correlationId));
+      }
       checkAndAddHeaders(recordId, chunkId, jobExecutionId, headers);
 
       kafkaRecord.addHeaders(headers);


### PR DESCRIPTION
## Purpose
`correlationId` header should be passed to all data-import events. It's needed to track events that are related to the same action.

## Approach
- Add correlationId to dataImportEventPayload schema
- Add populating correlationId header from event payload
- Cover with tests

## Learning
[MODDICORE-264](https://issues.folio.org/browse/MODDICORE-264)