### PR TITLE
MODINV-686 - Fixed addition of incoming fields which matches protection settings

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -796,30 +796,7 @@ public class MarcRecordModifier {
   }
 
   private boolean dataFieldsContain(List<DataField> dataFields, DataField dataField) {
-    return dataFields.stream().anyMatch(field -> fieldsEqual(field, dataField));
+    return dataFields.stream().anyMatch(field -> field.compareTo(dataField) == 0);
   }
 
-  private boolean fieldsEqual(DataField field1, DataField field2) {
-    return field1.getTag().equals(field2.getTag())
-      && field1.getIndicator1() == field2.getIndicator1()
-      && field1.getIndicator2() == field2.getIndicator2()
-      && subfieldsEqual(field1.getSubfields(), field2.getSubfields());
-  }
-
-  private boolean subfieldsEqual(List<Subfield> subfields1, List<Subfield> subfields2) {
-    if (subfields1.size() != subfields2.size()) {
-      return false;
-    }
-
-    for (int i = 0; i < subfields1.size(); i++) {
-      if (!subfieldsEqual(subfields1.get(i), subfields2.get(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private boolean subfieldsEqual(Subfield subfield1, Subfield subfield2) {
-    return subfield1.getCode() == subfield2.getCode() && subfield1.getData().equals(subfield2.getData());
-  }
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -726,7 +726,7 @@ public class MarcRecordModifier {
       dataFields.removeAll(tmpFields);
     }
 
-    if (ifNewDataShouldBeAdded && isNotProtected(fieldReplacement)) {
+    if (ifNewDataShouldBeAdded && !dataFieldsContain(marcRecordToChange.getDataFields(), fieldReplacement)) {
       updatedFields.add(fieldReplacement);
       addDataFieldInNumericalOrder(fieldReplacement);
     }
@@ -793,5 +793,33 @@ public class MarcRecordModifier {
     return controlFields.stream().anyMatch(field ->
         field.getTag().equals(controlField.getTag())
         && field.getData().equals(controlField.getData()));
+  }
+
+  private boolean dataFieldsContain(List<DataField> dataFields, DataField dataField) {
+    return dataFields.stream().anyMatch(field -> fieldsEqual(field, dataField));
+  }
+
+  private boolean fieldsEqual(DataField field1, DataField field2) {
+    return field1.getTag().equals(field2.getTag())
+      && field1.getIndicator1() == field2.getIndicator1()
+      && field1.getIndicator2() == field2.getIndicator2()
+      && subfieldsEqual(field1.getSubfields(), field2.getSubfields());
+  }
+
+  private boolean subfieldsEqual(List<Subfield> subfields1, List<Subfield> subfields2) {
+    if (subfields1.size() != subfields2.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < subfields1.size(); i++) {
+      if (!subfieldsEqual(subfields1.get(i), subfields2.get(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean subfieldsEqual(Subfield subfield1, Subfield subfield2) {
+    return subfield1.getCode() == subfield2.getCode() && subfield1.getData().equals(subfield2.getData());
   }
 }

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
@@ -1921,6 +1921,27 @@ public class MarcRecordModifierTest {
   }
 
   @Test
+  public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsProtectedAndIncomingFieldIsNotSameAndMatchesProtectionSettings() {
+    // 035 is repeatable field
+    // incoming 035 field also matches protection settings
+    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"new data\"},{\"b\":\"MiAaHDL\"}],\"ind1\":\"1\",\"ind2\":\"1\"}}]}";
+    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"123\"},{\"b\":\"MiAaHDL\"}],\"ind1\":\"1\",\"ind2\":\"1\"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00112nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"035\":{\"subfields\":[{\"a\":\"123\"},{\"b\":\"MiAaHDL\"}],\"ind1\":\"1\",\"ind2\":\"1\"}},{\"035\":{\"subfields\":[{\"a\":\"new data\"},{\"b\":\"MiAaHDL\"}],\"ind1\":\"1\",\"ind2\":\"1\"}}]}";
+
+    List<MarcFieldProtectionSetting> protectionSettings = List.of(
+      new MarcFieldProtectionSetting()
+        .withField("035")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfield("b")
+        .withData("MiAaHDL"));
+
+    MappingParameters mappingParameters = new MappingParameters()
+      .withMarcFieldProtectionSettings(protectionSettings);
+    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
+  }
+
+  @Test
   public void shouldRetainExistingRepeatableFieldWhenExistingIsProtectedAndHasNoIncomingFieldWithSameTag() {
     // 950 is repeatable field
     String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}]}";


### PR DESCRIPTION
## Purpose
to allow addition of incoming fields which matches protection settings to record during the record update


## Learning
[MODINV-686](https://issues.folio.org/browse/MODINV-686)
[MODDICORE-265](https://issues.folio.org/browse/MODDICORE-265)
