### PR TITLE
MODDICORE-280 Import is failing due to authoritySourceFiles

### DIFF
--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
@@ -1,5 +1,6 @@
 package org.folio.processing.mapping.defaultmapper.processor.parameters;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.apache.commons.collections4.list.UnmodifiableList;
 import org.folio.AlternativeTitleType;
 import org.folio.AuthorityNoteType;
@@ -36,6 +37,7 @@ import java.util.List;
 /**
  * Class to store parameters needed for mapping functions
  */
+@JsonIgnoreProperties("authoritySourceFiles")
 public class MappingParameters {
 
   private boolean initialized = false;


### PR DESCRIPTION
## Purpose
Fix import failing that is caused by unpopulated required authoritySourceFiles field.

## Approach
- 'authoritySourceFiles' field is marked to be ignored