### PR TITLE
MODSOURMAN-821 Assign each authority record to an Authority Source file list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
       <version>2.5.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.9.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <scm>

--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -245,6 +245,11 @@
         ]
       }
     },
+    "sourceFileId": {
+      "type": "string",
+      "description": "Authority source file id; UUID",
+      "$ref": "raml-storage/raml-util/schemas/uuid.schema"
+    },
     "metadata": {
       "type": "object",
       "description": "Creater, updater, creation date, last updated date",

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
@@ -60,13 +60,15 @@ public class Escaper {
    * @return
    */
   public static String escape(String data){
-    if (data == null) return "";
     return escape(data, false);
   }
-    public static String escape(String data, boolean keepTrailingBackslash){
-      if (data == null) return "";
-      // remove \ char if it is the last char of the text
-      if (!keepTrailingBackslash && data.endsWith("\\")) {
+
+  public static String escape(String data, boolean keepTrailingBackslash) {
+    if (data == null) {
+      return "";
+    }
+    // remove \ char if it is the last char of the text
+    if (!keepTrailingBackslash && data.endsWith("\\")) {
       data = data.substring(0, data.length() - 1);
     }
     data = removeEscapedChars(data).replaceAll("\\\"", "\\\\\"");

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
@@ -60,12 +60,13 @@ public class Escaper {
    * @return
    */
   public static String escape(String data){
+    if (data == null) return "";
     return escape(data, false);
   }
-
-  public static String escape(String data, boolean keepTrailingBackslash){
-    // remove \ char if it is the last char of the text
-    if (!keepTrailingBackslash && data.endsWith("\\")) {
+    public static String escape(String data, boolean keepTrailingBackslash){
+      if (data == null) return "";
+      // remove \ char if it is the last char of the text
+      if (!keepTrailingBackslash && data.endsWith("\\")) {
       data = data.substring(0, data.length() - 1);
     }
     data = removeEscapedChars(data).replaceAll("\\\"", "\\\\\"");

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -549,11 +549,10 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
   },
 
   SET_AUTHORITY_SOURCE_FILE_ID() {
-    private static final String CODE_PARAMETER = "code";
 
     @Override
     public String apply(RuleExecutionContext context) {
-      var value = context.getRuleParameter().getString(CODE_PARAMETER);
+      var value = context.getSubFieldValue();
       var authoritySourceFiles = context.getMappingParameters().getAuthoritySourceFiles();
 
       if (authoritySourceFiles == null || value == null) {

--- a/src/test/java/org/folio/processing/mapping/AuthorityMappingTest.java
+++ b/src/test/java/org/folio/processing/mapping/AuthorityMappingTest.java
@@ -4,8 +4,10 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import io.vertx.core.json.JsonObject;
+import org.folio.AuthoritySourceFile;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,14 +29,43 @@ public class AuthorityMappingTest {
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithTitles.json";
   private static final String PARSED_AUTHORITY_WITHOUT_TITLES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithoutTitles.json";
+  private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010 =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001And010.json";
+  private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010 =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010.json";
+  private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010WithMultipleSubfields.json";
   private static final String MAPPED_AUTHORITY_WITH_TITLES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithTitles.json";
   private static final String MAPPED_AUTHORITY_WITHOUT_TITLES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithoutTitles.json";
+  private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010 =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json";
+  private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010 =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010.json";
+  private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json";
   private static final String DEFAULT_MAPPING_RULES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/authorityRules.json";
 
   private final RecordMapper<Authority> mapper = RecordMapperBuilder.buildMapper("MARC_AUTHORITY");
+
+  private final List<AuthoritySourceFile> authoritySourceFiles = List.of(new AuthoritySourceFile()
+      .withId("e2efd148-8c17-41c2-9a4b-3d490db9b158")
+      .withName("LC Name Authority file (LCNAF)")
+      .withType("Names")
+      .withCodes(List.of("n", "nb", "nr", "no")),
+    new AuthoritySourceFile()
+      .withId("ce023941-e28d-40c1-910b-02e42d6ea2eb")
+      .withName("Faceted Application of Subject Terminology (FAST)")
+      .withType("Subjects")
+      .withCodes(List.of("fst")),
+    new AuthoritySourceFile()
+      .withId("6ccf7405-6ecf-4c16-9d84-a5bd0774e806")
+      .withName("LC Subject Headings (LCSH)")
+      .withType("Subjects")
+      .withCodes(List.of("sh"))
+  );
 
   @Test
   public void testMarcToAuthorityWithTitles() throws IOException {
@@ -53,6 +84,39 @@ public class AuthorityMappingTest {
 
     Authority actualMappedAuthority = mapper
       .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITHOUT_TITLES_PATH), new MappingParameters(), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  @Test
+  public void testMarcToAuthorityWithSourceFileAt010() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010),
+        new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  @Test
+  public void testMarcToAuthorityWithSourceFileAt001And010() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010),
+        new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  @Test
+  public void testMarcToAuthorityWithSourceFileAt010WithMultipleSubfields() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS),
+        new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
     Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
   }
 

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -869,7 +869,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("n", "nb", "nr", "no"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setRuleParameter(new JsonObject().put("code", "n12345"));
+    context.setSubFieldValue("n12345");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then
@@ -889,7 +889,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("nb", "nbsp"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(List.of(authoritySourceFile1, authoritySourceFile2)));
-    context.setRuleParameter(new JsonObject().put("code", "nbsp12345"));
+    context.setSubFieldValue("nbsp12345");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then
@@ -901,7 +901,7 @@ public class NormalizationFunctionTest {
     // given
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters());
-    context.setRuleParameter(new JsonObject().put("code", "n12345"));
+    context.setSubFieldValue("n12345");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then
@@ -919,7 +919,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("n", "nb", "nr", "no"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setRuleParameter(new JsonObject());
+    context.setSubFieldValue("");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then
@@ -937,7 +937,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("n", "nb", "nr", "no"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setRuleParameter(new JsonObject().put("code", "fst12345"));
+    context.setSubFieldValue("fst12345");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then
@@ -955,7 +955,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("n", "nb", "nr", "no"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setRuleParameter(new JsonObject().put("code", "12345"));
+    context.setSubFieldValue("12345");
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -20,6 +20,8 @@ import org.folio.CallNumberType;
 import org.folio.processing.mapping.defaultmapper.processor.RuleExecutionContext;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.marc4j.marc.DataField;
@@ -908,8 +910,9 @@ public class NormalizationFunctionTest {
     assertNull(actualAuthoritySourceFileId);
   }
 
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullWhenNoCodeSpecified() {
+  @ParameterizedTest
+  @ValueSource(strings = {"", "fst12345", "12345"})
+  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullWhenNoCodeSpecified(String subFieldValue) {
     // given
     var expectedAuthoritySourceFileId = UUID.randomUUID().toString();
     var authoritySourceFile = new AuthoritySourceFile()
@@ -919,43 +922,7 @@ public class NormalizationFunctionTest {
       .withCodes(List.of("n", "nb", "nr", "no"));
     var context = new RuleExecutionContext();
     context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setSubFieldValue("");
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertNull(actualAuthoritySourceFileId);
-  }
-
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullWhenNoMatchingFound() {
-    // given
-    var expectedAuthoritySourceFileId = UUID.randomUUID().toString();
-    var authoritySourceFile = new AuthoritySourceFile()
-      .withId(expectedAuthoritySourceFileId)
-      .withName("LC Name Authority file (LCNAF)")
-      .withType("Names")
-      .withCodes(List.of("n", "nb", "nr", "no"));
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setSubFieldValue("fst12345");
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertNull(actualAuthoritySourceFileId);
-  }
-
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullWhenNoPrefixSpecified() {
-    // given
-    var expectedAuthoritySourceFileId = UUID.randomUUID().toString();
-    var authoritySourceFile = new AuthoritySourceFile()
-      .withId(expectedAuthoritySourceFileId)
-      .withName("LC Name Authority file (LCNAF)")
-      .withType("Names")
-      .withCodes(List.of("n", "nb", "nr", "no"));
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setSubFieldValue("12345");
+    context.setSubFieldValue(subFieldValue);
     // when
     var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
     // then

--- a/src/test/resources/org/folio/processing/mapping/authority/authorityRules.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/authorityRules.json
@@ -22,6 +22,21 @@
           ]
         }
       ]
+    },
+    {
+      "skipIfTargetIsAssigned" : true,
+      "target": "sourceFileId",
+      "description": "Authority source file id",
+      "subfield": [],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_authority_source_file_id"
+            }
+          ]
+        }
+      ]
     }
   ],
   "008": [
@@ -84,6 +99,21 @@
                   "type": "trim"
                 }
               ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "skipIfTargetIsAssigned" : true,
+      "target": "sourceFileId",
+      "description": "Authority source file id",
+      "subfield": ["a"],
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "set_authority_source_file_id"
             }
           ]
         }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json
@@ -1,0 +1,51 @@
+{
+  "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
+  "sftPersonalName": [ ],
+  "saftPersonalName": [ ],
+  "personalNameTitle": "Eimermacher, Karl CtY MBTI CtY MBTI NIC CStRLIN NIC",
+  "sftPersonalNameTitle": [ "v. 25 cm." ],
+  "saftPersonalNameTitle": [ "Editor:   C. W. Dugmore." ],
+  "sftCorporateName": [],
+  "saftCorporateName": [ ],
+  "corporateNameTitle": "BR140 .J6",
+  "sftCorporateNameTitle": [ "Quarterly, 1970-" ],
+  "saftCorporateNameTitle": [ "Church history" ],
+  "sftMeetingName": [ ],
+  "saftMeetingName": [ ],
+  "meetingNameTitle": "270.05",
+  "sftMeetingNameTitle": [ "Semiannual, 1950-69" ],
+  "saftMeetingNameTitle": [ "Church history" ],
+  "uniformTitle": "The Journal of ecclesiastical history",
+  "sftUniformTitle": [ "v. 1-   Apr. 1950-" ],
+  "saftUniformTitle": [ "Periodicals" ],
+  "topicalTerm": "The Journal of ecclesiastical history.",
+  "sftTopicalTerm": [ "note$a note$5" ],
+  "saftTopicalTerm": [ "Dugmore, C. W." ],
+  "subjectHeadings": "a",
+  "geographicName": "London,",
+  "sftGeographicName": [ "note$a note$5" ],
+  "saftGeographicName": [ "callNumber2" ],
+  "genreTerm": "32 East 57th St., New York, 10022",
+  "sftGenreTerm": [ "note$a note$i note$x note$z note$5" ],
+  "saftGenreTerm": [ "linkText publicNote" ],
+  "identifiers": [
+    {
+      "value": "fst1000649",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "n   58020553",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "0022-0469",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "(CStRLIN)NYCX1604275S",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    }
+  ],
+  "notes": [ ],
+  "sourceFileId" : "ce023941-e28d-40c1-910b-02e42d6ea2eb"
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010.json
@@ -1,0 +1,51 @@
+{
+  "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
+  "sftPersonalName": [ ],
+  "saftPersonalName": [ ],
+  "personalNameTitle": "Eimermacher, Karl CtY MBTI CtY MBTI NIC CStRLIN NIC",
+  "sftPersonalNameTitle": [ "v. 25 cm." ],
+  "saftPersonalNameTitle": [ "Editor:   C. W. Dugmore." ],
+  "sftCorporateName": [],
+  "saftCorporateName": [ ],
+  "corporateNameTitle": "BR140 .J6",
+  "sftCorporateNameTitle": [ "Quarterly, 1970-" ],
+  "saftCorporateNameTitle": [ "Church history" ],
+  "sftMeetingName": [ ],
+  "saftMeetingName": [ ],
+  "meetingNameTitle": "270.05",
+  "sftMeetingNameTitle": [ "Semiannual, 1950-69" ],
+  "saftMeetingNameTitle": [ "Church history" ],
+  "uniformTitle": "The Journal of ecclesiastical history",
+  "sftUniformTitle": [ "v. 1-   Apr. 1950-" ],
+  "saftUniformTitle": [ "Periodicals" ],
+  "topicalTerm": "The Journal of ecclesiastical history.",
+  "sftTopicalTerm": [ "note$a note$5" ],
+  "saftTopicalTerm": [ "Dugmore, C. W." ],
+  "subjectHeadings": "a",
+  "geographicName": "London,",
+  "sftGeographicName": [ "note$a note$5" ],
+  "saftGeographicName": [ "callNumber2" ],
+  "genreTerm": "32 East 57th St., New York, 10022",
+  "sftGenreTerm": [ "note$a note$i note$x note$z note$5" ],
+  "saftGenreTerm": [ "linkText publicNote" ],
+  "identifiers": [
+    {
+      "value": "1000649",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "n   58020553",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "0022-0469",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "(CStRLIN)NYCX1604275S",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    }
+  ],
+  "notes": [ ],
+  "sourceFileId" : "e2efd148-8c17-41c2-9a4b-3d490db9b158"
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json
@@ -1,0 +1,79 @@
+{
+  "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
+  "sftPersonalName": [],
+  "saftPersonalName": [],
+  "personalNameTitle": "Eimermacher, Karl CtY MBTI CtY MBTI NIC CStRLIN NIC",
+  "sftPersonalNameTitle": [
+    "v. 25 cm."
+  ],
+  "saftPersonalNameTitle": [
+    "Editor:   C. W. Dugmore."
+  ],
+  "sftCorporateName": [],
+  "saftCorporateName": [],
+  "corporateNameTitle": "BR140 .J6",
+  "sftCorporateNameTitle": [
+    "Quarterly, 1970-"
+  ],
+  "saftCorporateNameTitle": [
+    "Church history"
+  ],
+  "sftMeetingName": [],
+  "saftMeetingName": [],
+  "meetingNameTitle": "270.05",
+  "sftMeetingNameTitle": [
+    "Semiannual, 1950-69"
+  ],
+  "saftMeetingNameTitle": [
+    "Church history"
+  ],
+  "uniformTitle": "The Journal of ecclesiastical history",
+  "sftUniformTitle": [
+    "v. 1-   Apr. 1950-"
+  ],
+  "saftUniformTitle": [
+    "Periodicals"
+  ],
+  "topicalTerm": "The Journal of ecclesiastical history.",
+  "sftTopicalTerm": [
+    "note$a note$5"
+  ],
+  "saftTopicalTerm": [
+    "Dugmore, C. W."
+  ],
+  "subjectHeadings": "a",
+  "geographicName": "London,",
+  "sftGeographicName": [
+    "note$a note$5"
+  ],
+  "saftGeographicName": [
+    "callNumber2"
+  ],
+  "genreTerm": "32 East 57th St., New York, 10022",
+  "sftGenreTerm": [
+    "note$a note$i note$x note$z note$5"
+  ],
+  "saftGenreTerm": [
+    "linkText publicNote"
+  ],
+  "identifiers": [
+    {
+      "value": "1000649",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "58020553  n   58020553  sh   58020553",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "0022-0469",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "(CStRLIN)NYCX1604275S",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    }
+  ],
+  "notes": [],
+  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158"
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001And010.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001And010.json
@@ -1,0 +1,482 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "fst1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "n   58020553 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010.json
@@ -1,0 +1,482 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "n   58020553 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010WithMultipleSubfields.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010WithMultipleSubfields.json
@@ -1,0 +1,484 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "   58020553 ",
+            "a": "n   58020553 ",
+            "a": "sh   58020553 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
Implement rules for mapping Authority Source File Id. As not all the requirements can be met using the currently existing MARC rule mapping implementation, new flag was added. 
[MODSOURMAN-821](https://issues.folio.org/browse/MODSOURMAN-821)

## Approach
- Flag "skipIfTargetIsAssigned" indicating whether a rule should be skipped when target value is already assigned added
- Authority Source File Id mapping tests and corresponding json files for them added
- Existing implementation of SET_AUTHORITY_SOURCE_FILE_ID function changed to use MARC field value instead of the rule parameter