### PR TITLE
MODDICORE-281 Extend instance contributors schema with Authority ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2022-xx-xx v3.5.0-SNAPSHOT
+* [MODDICORE-281](https://issues.folio.org/browse/MODDICORE-281) Extend instance contributors schema with Authority ID
+
 ## 2022-06-23 v3.4.0
 * [MODINV-671](https://issues.folio.org/browse/MODINV-671) Check and fix the sending of DI_ERROR after DuplicateEventException appears
 * [MODDICORE-265](https://issues.folio.org/browse/MODDICORE-265) Implement method to update record fields according to field protections

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -163,6 +163,10 @@
             "type": "string",
             "description": "Contributor type terms defined by the MARC code list for relators"
           },
+          "authorityId": {
+            "type": "string",
+            "description": "ID of authority record that controls the contributor"
+          },
           "primary": {
             "type": "boolean",
             "description": "Whether this is the primary contributor"

--- a/src/test/resources/org/folio/processing/mapping/instance/rules.json
+++ b/src/test/resources/org/folio/processing/mapping/instance/rules.json
@@ -1081,6 +1081,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -1183,6 +1191,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -1282,6 +1298,14 @@
   "111": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",
@@ -6142,6 +6166,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Personal Name",
           "applyRulesOnConcatenatedData": true,
@@ -6244,6 +6276,14 @@
     {
       "entity": [
         {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
+        {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Corporate Name",
           "applyRulesOnConcatenatedData": true,
@@ -6343,6 +6383,14 @@
   "711": [
     {
       "entity": [
+        {
+          "target": "contributors.authorityId",
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true,
+          "subfield": [
+            "9"
+          ]
+        },
         {
           "target": "contributors.contributorNameTypeId",
           "description": "Type for Meeting Name",


### PR DESCRIPTION
## Purpose
It's needed to have ability to map authority ID into a instance contributor controlled by authority

## Approach
Extend instance.contributors with authorityId