### PR TITLE
MODDICORE-283 Change logic of sourceFileId populating by adding Authority Natural ID

### DIFF
--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -250,6 +250,10 @@
       "description": "Authority source file id; UUID",
       "$ref": "raml-storage/raml-util/schemas/uuid.schema"
     },
+    "naturalId": {
+      "type": "string",
+      "description": "Authority Natural ID"
+    },
     "metadata": {
       "type": "object",
       "description": "Creater, updater, creation date, last updated date",

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToAuthorityMapper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToAuthorityMapper.java
@@ -1,10 +1,22 @@
 package org.folio.processing.mapping.defaultmapper;
 
-import io.vertx.core.json.JsonObject;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
+import io.vertx.core.json.JsonObject;
+import java.io.ByteArrayInputStream;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.folio.Authority;
+import org.folio.AuthoritySourceFile;
 import org.folio.processing.mapping.defaultmapper.processor.Processor;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.marc4j.MarcJsonReader;
+import org.marc4j.marc.ControlField;
+import org.marc4j.marc.Record;
+import org.marc4j.marc.Subfield;
 
 public class MarcToAuthorityMapper implements RecordMapper<Authority> {
 
@@ -12,12 +24,91 @@ public class MarcToAuthorityMapper implements RecordMapper<Authority> {
 
   @Override
   public Authority mapRecord(JsonObject parsedRecord, MappingParameters mappingParameters, JsonObject mappingRules) {
-    return new Processor<Authority>().process(parsedRecord, mappingParameters, mappingRules, Authority.class);
+    var authority = new Processor<Authority>().process(parsedRecord, mappingParameters, mappingRules, Authority.class);
+
+    linkSourceFile(parsedRecord, mappingParameters, authority);
+
+    return authority;
   }
 
   @Override
   public String getMapperFormat() {
     return MARC_FORMAT;
+  }
+
+  private void linkSourceFile(JsonObject parsedRecord, MappingParameters mappingParameters, Authority authority) {
+    var sourceFiles = mappingParameters.getAuthoritySourceFiles();
+    if (sourceFiles == null || sourceFiles.isEmpty()) {
+      return;
+    }
+
+    var reader = new MarcJsonReader(new ByteArrayInputStream(parsedRecord.toString().getBytes(UTF_8)));
+    if (reader.hasNext()) {
+      findAndLinkSourceFile(authority, sourceFiles, reader.next());
+    }
+  }
+
+  private void findAndLinkSourceFile(Authority authority, List<AuthoritySourceFile> sourceFiles, Record marcRecord) {
+    String sourceFileId = null;
+    String naturalId = null;
+
+    var tag010ASubfieldValues = getTag010ASubfieldValues(marcRecord);
+    for (var aSubfieldValue : tag010ASubfieldValues) {
+      if ((sourceFileId = findSourceFileByTagValue(sourceFiles, aSubfieldValue)) != null) {
+        naturalId = aSubfieldValue;
+        break;
+      }
+    }
+
+    if (sourceFileId == null) {
+      var tag001Value = getTag001Value(marcRecord);
+
+      sourceFileId = findSourceFileByTagValue(sourceFiles, tag001Value);
+      naturalId = tag001Value;
+    }
+
+    authority.setSourceFileId(sourceFileId);
+    authority.setNaturalId(removeWhitespaces(naturalId));
+  }
+
+  private List<String> getTag010ASubfieldValues(Record marcRecord) {
+    return marcRecord.getDataFields().stream().filter(f -> f.getTag().equals("010"))
+      .map(tag -> tag.getSubfields('a'))
+      .flatMap(List::stream)
+      .map(Subfield::getData)
+      .collect(Collectors.toList());
+  }
+
+  private String getTag001Value(Record marcRecord) {
+    return marcRecord.getControlFields().stream().filter(f -> f.getTag().equals("001"))
+      .findFirst()
+      .map(ControlField::getData)
+      .orElse(null);
+  }
+
+  private String findSourceFileByTagValue(List<AuthoritySourceFile> sourceFiles, String value) {
+    if (value == null) {
+      return null;
+    }
+
+    var codeIdsMap = sourceFiles.stream().map(file -> {
+        var id = file.getId();
+        return file.getCodes().stream().collect(Collectors.toMap(code -> code, code -> id));
+      }).flatMap(map -> map.entrySet().stream())
+      .sorted(Comparator.comparing(codeIdEntry -> -codeIdEntry.getKey().length()))
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+        (v1, v2) -> v2,
+        LinkedHashMap::new));
+
+    return codeIdsMap.entrySet().stream()
+      .filter(codeIdEntry -> value.startsWith(codeIdEntry.getKey()))
+      .map(Map.Entry::getValue)
+      .findFirst()
+      .orElse(null);
+  }
+
+  private static String removeWhitespaces(String str) {
+    return str == null ? null : str.replaceAll("\\s+", "");
   }
 
 }

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -51,7 +51,6 @@ public class Processor<T> {
   private static final String IND_2 = "ind2";
   private static final String WILDCARD_INDICATOR = "*";
   private static final String TARGET = "target";
-  private static final String SKIP_IF_TARGET_IS_ASSIGNED = "skipIfTargetIsAssigned";
 
   private JsonObject mappingRules;
 
@@ -64,7 +63,6 @@ public class Processor<T> {
   private boolean entityRequested;
   private boolean entityRequestedPerRepeatedSubfield;
   private boolean keepTrailingBackslash;
-  private boolean valueIsAssigned;
   private final List<StringBuilder> buffers2concat = new ArrayList<>();
   private final Map<String, StringBuilder> subField2Data = new HashMap<>();
   private final Map<String, String> subField2Delimiter = new HashMap<>();
@@ -131,11 +129,6 @@ public class Processor<T> {
       //there could be multiple mapping entries, specifically different mappings
       //per subfield in the marc field
       JsonObject subFieldMapping = mappingEntry.getJsonObject(i);
-
-      if (shouldSkipRuleWhenTargetIsAssigned(subFieldMapping)){
-        return;
-      }
-
       //check if mapping entry has indicators sets
       if (!fieldMappingIndicators.isEmpty()) {
         String dataFieldInd1 = String.valueOf(dataField.getIndicator1());
@@ -223,8 +216,6 @@ public class Processor<T> {
 
     //for subfields there could be the case when you need to keep trailing backslash instead of removing it
     keepTrailingBackslash = BooleanUtils.isTrue(subFieldMapping.getBoolean("keepTrailingBackslash"));
-
-    valueIsAssigned = false;
 
     //if no "entity" is defined , then all rules contents of the field getting mapped to the same type
     //will be placed in a single instance of that type.
@@ -359,8 +350,7 @@ public class Processor<T> {
 
     for (int i = 0; i < subFields.size(); i++) {
       //check if there are no mapped elements present
-      if (checkIfSubfieldShouldBeHandled(subFieldsSet, subFields.get(i)) && canHandleSubField(subFields.get(i), jObj)
-      && !shouldSkipSubfieldWhenTargetIsAssigned(jObj)) {
+      if (checkIfSubfieldShouldBeHandled(subFieldsSet, subFields.get(i)) && canHandleSubField(subFields.get(i), jObj)) {
         handleSubFields(ruleExecutionContext, subFields, i, subFieldsSet, arraysOfObjects, applyPost, embeddedFields);
       }
     }
@@ -415,9 +405,6 @@ public class Processor<T> {
       //which has the full set of subfield data
       ruleExecutionContext.setSubFieldValue(data);
       data = processRules(ruleExecutionContext);
-      if (data.length() > 0){
-        valueIsAssigned = true;
-      }
     }
 
     if (delimiters != null && subField2Data.get(String.valueOf(subfield)) != null) {
@@ -505,10 +492,6 @@ public class Processor<T> {
 
     for (int i = 0; i < controlFieldRules.size(); i++) {
       JsonObject cfRule = controlFieldRules.getJsonObject(i);
-
-      if (shouldSkipRuleWhenTargetIsAssigned(cfRule)){
-        return;
-      }
 
       //get rules - each rule can contain multiple conditions that need to be met and a
       //value to inject in case all the conditions are met
@@ -902,35 +885,4 @@ public class Processor<T> {
     return subFieldsSet.isEmpty() || subFieldsSet.contains(Character.toString(subfield.getCode()));
   }
 
-  private boolean shouldSkipRuleWhenTargetIsAssigned(JsonObject subFieldMapping){
-    if (subFieldMapping.containsKey(SKIP_IF_TARGET_IS_ASSIGNED)) {
-      boolean isAssigned = subFieldMapping.getBoolean(SKIP_IF_TARGET_IS_ASSIGNED);
-      if (isAssigned) {
-        String[] embeddedFields = subFieldMapping.getString(TARGET).split("\\.");
-        Object target = entity;
-        Class<?> type = entity.getClass();
-        for (String pathSegment : embeddedFields) {
-          try {
-            var getValueMethod = type.getMethod
-              ("get" + Character.toUpperCase(pathSegment.charAt(0)) + pathSegment.substring(1));
-            target = getValueMethod.invoke(target);
-            if (target == null) {
-              return false;
-            }
-            type = target.getClass();
-          } catch (Exception e) {
-            LOGGER.error(e.getMessage(), e);
-            return true;
-          }
-        }
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean shouldSkipSubfieldWhenTargetIsAssigned(JsonObject subFieldMapping){
-    return subFieldMapping.containsKey(SKIP_IF_TARGET_IS_ASSIGNED) &&
-      subFieldMapping.getBoolean(SKIP_IF_TARGET_IS_ASSIGNED) && valueIsAssigned;
-  }
 }

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -28,10 +28,7 @@ import org.folio.processing.mapping.defaultmapper.processor.publisher.PublisherR
 import org.marc4j.marc.DataField;
 import org.marc4j.marc.Subfield;
 
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Collections;

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -546,34 +546,6 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
         .findFirst()
         .orElse(STUB_FIELD_TYPE_ID);
     }
-  },
-
-  SET_AUTHORITY_SOURCE_FILE_ID() {
-
-    @Override
-    public String apply(RuleExecutionContext context) {
-      var value = context.getSubFieldValue();
-      var authoritySourceFiles = context.getMappingParameters().getAuthoritySourceFiles();
-
-      if (authoritySourceFiles == null || value == null) {
-        return null;
-      }
-
-      var codeIdsMap = authoritySourceFiles.stream().map(file -> {
-          var id = file.getId();
-          return file.getCodes().stream().collect(Collectors.toMap(code -> code, code -> id));
-        }).flatMap(map -> map.entrySet().stream())
-        .sorted(Comparator.comparing(codeIdEntry -> -codeIdEntry.getKey().length()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-          (v1, v2) -> v2,
-          LinkedHashMap::new));
-
-      return codeIdsMap.entrySet().stream()
-        .filter(codeIdEntry -> value.startsWith(codeIdEntry.getKey()))
-        .map(Map.Entry::getValue)
-        .findFirst()
-        .orElse(null);
-    }
   };
 
   public IssuanceModeEnum matchSymbolToIssuanceMode(char symbol) {

--- a/src/test/java/org/folio/processing/mapping/AuthorityMappingTest.java
+++ b/src/test/java/org/folio/processing/mapping/AuthorityMappingTest.java
@@ -31,20 +31,28 @@ public class AuthorityMappingTest {
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithoutTitles.json";
   private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010 =
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001And010.json";
+  private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_001 =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001.json";
   private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010 =
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010.json";
   private static final String PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS =
     "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt010WithMultipleSubfields.json";
+  private static final String PARSED_AUTHORITY_WITHOUT_SOURCE_FILE =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithoutSourceFile.json";
   private static final String MAPPED_AUTHORITY_WITH_TITLES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithTitles.json";
   private static final String MAPPED_AUTHORITY_WITHOUT_TITLES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithoutTitles.json";
   private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_001_AND_010 =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json";
+  private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_001 =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001.json";
   private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010 =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010.json";
   private static final String MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS =
     "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json";
+  private static final String MAPPED_AUTHORITY_WITHOUT_SOURCE_FILE =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithoutSourceFile.json";
   private static final String DEFAULT_MAPPING_RULES_PATH =
     "src/test/resources/org/folio/processing/mapping/authority/authorityRules.json";
 
@@ -110,12 +118,34 @@ public class AuthorityMappingTest {
   }
 
   @Test
+  public void testMarcToAuthorityWithSourceFileAt001() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_001));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_001),
+        new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  @Test
   public void testMarcToAuthorityWithSourceFileAt010WithMultipleSubfields() throws IOException {
     JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS));
     JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
 
     Authority actualMappedAuthority = mapper
       .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITH_SOURCE_FILE_AT_010_WITH_MULTIPLE_SUBFIELDS),
+        new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  @Test
+  public void testMarcToAuthorityWithoutSourceFile_defaultNaturalId() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_WITHOUT_SOURCE_FILE));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(PARSED_AUTHORITY_WITHOUT_SOURCE_FILE),
         new MappingParameters().withAuthoritySourceFiles(authoritySourceFiles), mappingRules);
     Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
   }

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -4,7 +4,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.AuthorityNoteType;
-import org.folio.AuthoritySourceFile;
 import org.folio.ClassificationType;
 import org.folio.InstanceType;
 import org.folio.ElectronicAccessRelationship;
@@ -20,8 +19,6 @@ import org.folio.CallNumberType;
 import org.folio.processing.mapping.defaultmapper.processor.RuleExecutionContext;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.marc4j.marc.DataField;
@@ -37,7 +34,6 @@ import java.util.Arrays;
 import static io.netty.util.internal.StringUtil.EMPTY_STRING;
 import static org.folio.processing.mapping.defaultmapper.processor.functions.NormalizationFunctionRunner.runFunction;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 @RunWith(JUnit4.class)
 public class NormalizationFunctionTest {
@@ -858,75 +854,6 @@ public class NormalizationFunctionTest {
     var actualInstanceNoteTypeId = runFunction("set_authority_note_type_id", context);
     // then
     assertEquals(STUB_FIELD_TYPE_ID, actualInstanceNoteTypeId);
-  }
-
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnExpectedResult() {
-    // given
-    var expectedAuthoritySourceFileId = UUID.randomUUID().toString();
-    var authoritySourceFile = new AuthoritySourceFile()
-      .withId(expectedAuthoritySourceFileId)
-      .withName("LC Name Authority file (LCNAF)")
-      .withType("Names")
-      .withCodes(List.of("n", "nb", "nr", "no"));
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setSubFieldValue("n12345");
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertEquals(expectedAuthoritySourceFileId, actualAuthoritySourceFileId);
-  }
-
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnExpectedResultWhenMultipleMatches() {
-    // given
-    var authoritySourceFileId1 = UUID.randomUUID().toString();
-    var authoritySourceFile1 = new AuthoritySourceFile()
-      .withId(authoritySourceFileId1)
-      .withCodes(List.of("n", "nbs"));
-    var authoritySourceFileId2 = UUID.randomUUID().toString();
-    var authoritySourceFile2 = new AuthoritySourceFile()
-      .withId(authoritySourceFileId2)
-      .withCodes(List.of("nb", "nbsp"));
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(List.of(authoritySourceFile1, authoritySourceFile2)));
-    context.setSubFieldValue("nbsp12345");
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertEquals(authoritySourceFileId2, actualAuthoritySourceFileId);
-  }
-
-  @Test
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullIfNoMappingsSpecified() {
-    // given
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters());
-    context.setSubFieldValue("n12345");
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertNull(actualAuthoritySourceFileId);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"", "fst12345", "12345"})
-  public void SET_AUTHORITY_SOURCE_FILE_ID_shouldReturnNullWhenNoCodeSpecified(String subFieldValue) {
-    // given
-    var expectedAuthoritySourceFileId = UUID.randomUUID().toString();
-    var authoritySourceFile = new AuthoritySourceFile()
-      .withId(expectedAuthoritySourceFileId)
-      .withName("LC Name Authority file (LCNAF)")
-      .withType("Names")
-      .withCodes(List.of("n", "nb", "nr", "no"));
-    var context = new RuleExecutionContext();
-    context.setMappingParameters(new MappingParameters().withAuthoritySourceFiles(Collections.singletonList(authoritySourceFile)));
-    context.setSubFieldValue(subFieldValue);
-    // when
-    var actualAuthoritySourceFileId = runFunction("set_authority_source_file_id", context);
-    // then
-    assertNull(actualAuthoritySourceFileId);
   }
 
   private List<HoldingsType> getHoldingsMappingParameter() {

--- a/src/test/resources/org/folio/processing/mapping/authority/authorityRules.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/authorityRules.json
@@ -22,21 +22,6 @@
           ]
         }
       ]
-    },
-    {
-      "skipIfTargetIsAssigned" : true,
-      "target": "sourceFileId",
-      "description": "Authority source file id",
-      "subfield": [],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "set_authority_source_file_id"
-            }
-          ]
-        }
-      ]
     }
   ],
   "008": [
@@ -99,21 +84,6 @@
                   "type": "trim"
                 }
               ]
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "skipIfTargetIsAssigned" : true,
-      "target": "sourceFileId",
-      "description": "Authority source file id",
-      "subfield": ["a"],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "set_authority_source_file_id"
             }
           ]
         }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001.json
@@ -30,11 +30,11 @@
   "saftGenreTerm": [ "linkText publicNote" ],
   "identifiers": [
     {
-      "value": "1000649",
+      "value": "fst1000649",
       "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
     },
     {
-      "value": "n   58020553",
+      "value": "abc   38420221",
       "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
     },
     {
@@ -47,6 +47,6 @@
     }
   ],
   "notes": [ ],
-  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158",
-  "naturalId": "n58020553"
+  "sourceFileId": "ce023941-e28d-40c1-910b-02e42d6ea2eb",
+  "naturalId": "fst1000649"
 }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt001And010.json
@@ -47,5 +47,6 @@
     }
   ],
   "notes": [ ],
-  "sourceFileId" : "ce023941-e28d-40c1-910b-02e42d6ea2eb"
+  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158",
+  "naturalId": "n58020553"
 }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithSourceFileAt010WithMultipleSubfields.json
@@ -75,5 +75,6 @@
     }
   ],
   "notes": [],
-  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158"
+  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158",
+  "naturalId": "n58020553"
 }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithoutSourceFile.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordWithoutSourceFile.json
@@ -30,11 +30,11 @@
   "saftGenreTerm": [ "linkText publicNote" ],
   "identifiers": [
     {
-      "value": "1000649",
+      "value": "xyz1000649",
       "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
     },
     {
-      "value": "n   58020553",
+      "value": "abc   38420221",
       "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
     },
     {
@@ -47,6 +47,5 @@
     }
   ],
   "notes": [ ],
-  "sourceFileId": "e2efd148-8c17-41c2-9a4b-3d490db9b158",
-  "naturalId": "n58020553"
+  "naturalId": "xyz1000649"
 }

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithSourceFileAt001.json
@@ -1,0 +1,482 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "fst1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "abc   38420221 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithoutSourceFile.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordWithoutSourceFile.json
@@ -1,0 +1,482 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "xyz1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "abc   38420221 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**Purpose**
It's needed to have information of an Authority Natural ID to use it in a link in the $0 subfield of linked bib fields. This Natural ID should be the ID by which Authority File ID was determined.
Also, it's needed because requirements were not clear for populating Source File ([MODINVSTOR-892](https://issues.folio.org/browse/MODINVSTOR-892)) it was just check 001 and 010$a fields but was changed to check first 010$a and then check 001.

JIRA: https://issues.folio.org/browse/MODDICORE-283

**Approach**
- move logic from SET_AUTHORITY_SOURCE_FILE_ID to MarcToAuthorityMapper
- check first 010$a subfield and if it is not suited by criteria for identifying Authority File ID then check 001 field
- when Authority File ID is identified also populate `naturalId` field of authority
- if Authority File ID can't be identified then it will be `null` and Natural ID will be the value from the 001 field