### PR TITLE
[MODDATAIMP-736] Adjust logging configuration to display datetime in a proper format

### DIFF
--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -5,13 +5,14 @@ filter.threshold.level = info
 
 appenders = console
 
-packages = org.folio.okapi.common.logging
-
 appender.console.type = Console
 appender.console.name = STDOUT
+appender.console.layout.type = JSONLayout
+appender.console.layout.compact = true
+appender.console.layout.eventEol = true
+appender.console.layout.stacktraceAsString = true
 
-appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n
+packages = org.folio.okapi.common.logging
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Purpose
Adjust logging configuration to display datetime in a proper format

## Approach
Changed config files