### PR TITLE
MODDICORE-293 Handle bib-authority link when user updates a bib record via data import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,7 @@
                 <path>${basedir}/ramls/raml-storage/schemas/mod-data-import-converter-storage/marc-field-protection/marcFieldProtectionSettingsCollection.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/dto/record.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/dto/edifactParsedContent.json</path>
+                <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/instanceLinkDtoCollection.json</path>
                 <path>${basedir}/ramls/event.json</path>
                 <path>${basedir}/ramls/instance.json</path>
                 <path>${basedir}/ramls/holdings.json</path>

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -1,0 +1,122 @@
+package org.folio.processing.mapping.mapper.writer.marc;
+
+import static java.util.Collections.emptyList;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.folio.DataImportEventPayload;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.Link;
+import org.folio.MappingProfile;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.marc4j.marc.DataField;
+
+public class MarcBibRecordModifier extends MarcRecordModifier {
+
+  private static final char SUBFIELD_0 = '0';
+
+  private List<Link> bibAuthorityLinks = emptyList();
+  private final Set<Link> bibAuthorityLinksKept = new HashSet<>();
+
+  public List<Link> getBibAuthorityLinksKept() {
+    return new LinkedList<>(bibAuthorityLinksKept);
+  }
+
+  public void initialize(DataImportEventPayload eventPayload, MappingParameters mappingParameters,
+                         MappingProfile mappingProfile, EntityType marcType,
+                         InstanceLinkDtoCollection links) throws IOException {
+    validateEntityType(marcType);
+    initialize(eventPayload, mappingParameters, mappingProfile, marcType);
+    if (links == null || links.getLinks() == null) {
+      return;
+    }
+    bibAuthorityLinks = links.getLinks();
+  }
+
+  /**
+   * Should call regular update subfield flow only for uncontrolled subfields
+   * */
+  @Override
+  protected boolean updateSubfields(String subfieldCode, List<DataField> tmpFields, DataField fieldToUpdate,
+                                    DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
+    var linkOptional = getLink(fieldToUpdate);
+    if (linkOptional.isPresent() && fieldsLinked(fieldReplacement, fieldToUpdate)) {
+      var link = linkOptional.get();
+      bibAuthorityLinksKept.add(link);
+      return updateUncontrolledSubfields(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
+    }
+
+    return super.updateSubfields(subfieldCode, tmpFields, fieldToUpdate, fieldReplacement, ifNewDataShouldBeAdded);
+  }
+
+  @Override
+  protected boolean unUpdatedFieldShouldBeRemoved(DataField dataField) {
+    return super.unUpdatedFieldShouldBeRemoved(dataField) && !fieldLinked(dataField);
+  }
+
+  private boolean updateUncontrolledSubfields(Link link, String subfieldCode, List<DataField> tmpFields,
+                                              DataField fieldToUpdate, DataField fieldReplacement) {
+    if (subfieldCode.equals(ANY_STRING)) {
+      fieldReplacement.getSubfields()
+        .forEach(subfield ->
+          updateUncontrolledSubfield(link, String.valueOf(subfield.getCode()), tmpFields, fieldToUpdate, fieldReplacement));
+    } else {
+      updateUncontrolledSubfield(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
+    }
+
+    return false;
+  }
+
+  private void updateUncontrolledSubfield(Link link, String subfieldCode, List<DataField> tmpFields,
+                                          DataField fieldToUpdate, DataField fieldReplacement) {
+    if (subfieldLinked(link, subfieldCode)) {
+      return;
+    }
+
+    super.updateSubfields(subfieldCode, tmpFields, fieldToUpdate, fieldReplacement, false);
+  }
+
+  private Optional<Link> getLink(DataField dataField) {
+    return bibAuthorityLinks.stream()
+      .filter(link -> link.getBibRecordTag().equals(dataField.getTag()))
+      .findFirst();
+  }
+
+  private boolean subfieldLinked(Link link, String subfieldCode) {
+    return link.getBibRecordSubfields().contains(subfieldCode) || subfieldCode.charAt(0) == SUBFIELD_0;
+  }
+
+  /**
+   * Indicates that incoming and existing fields hold the same link
+   * */
+  private boolean fieldsLinked(DataField incomingField, DataField fieldToChange) {
+    var incomingSubfield0 = incomingField.getSubfield(SUBFIELD_0);
+    var existingSubfield0 = fieldToChange.getSubfield(SUBFIELD_0);
+    return incomingSubfield0 != null
+      && existingSubfield0 != null
+      && incomingSubfield0.getData().equals(existingSubfield0.getData());
+  }
+
+  /**
+   * Indicates that field is still linked after update
+   * */
+  private boolean fieldLinked(DataField dataField) {
+    var subfield0 = dataField.getSubfield(SUBFIELD_0);
+    var linkKept = bibAuthorityLinksKept.stream()
+      .anyMatch(link -> link.getBibRecordTag().equals(dataField.getTag()));
+
+    return subfield0 != null && linkKept;
+  }
+
+  private void validateEntityType(EntityType entityType) {
+    if (!entityType.equals(EntityType.MARC_BIBLIOGRAPHIC)) {
+      throw new IllegalArgumentException(this.getClass().getSimpleName() + " support only "
+        + EntityType.MARC_BIBLIOGRAPHIC.value());
+    }
+  }
+}

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -1,0 +1,194 @@
+package org.folio.processing.mapping.mapper.writer.marc;
+
+import static io.vertx.core.json.jackson.DatabindCodec.mapper;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.RandomUtils.nextInt;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.MappingDetail.MarcMappingOption.UPDATE;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import org.folio.DataImportEventPayload;
+import org.folio.InstanceLinkDtoCollection;
+import org.folio.Link;
+import org.folio.MappingProfile;
+import org.folio.ParsedRecord;
+import org.folio.Record;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MarcField;
+import org.folio.rest.jaxrs.model.MarcMappingDetail;
+import org.folio.rest.jaxrs.model.MarcSubfield;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
+
+  private final MarcBibRecordModifier marcBibRecordModifier;
+
+  public MarcBibRecordModifierTest() {
+    marcBibRecordModifier = new MarcBibRecordModifier();
+    marcRecordModifier = marcBibRecordModifier;
+  }
+
+  //no mapping details tests
+  @Test
+  public void shouldRemoveLinksOnFieldsRemoval() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}]}";
+    var expectedParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
+  }
+
+  @Test
+  public void shouldNotUpdateLinkedSubfields() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00111nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
+  }
+
+  @Test
+  public void shouldRemoveLinksOnSubfield0Removal() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00113nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
+  }
+
+  @Test
+  public void shouldRemoveLinksOnSubfield0Change() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00120nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
+  }
+
+  //custom mapping details tests
+  @Test
+  public void shouldNotUpdateLinkedSubfieldWhenOnlySubfieldMapped() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00103nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, constructMappingDetails("a"), 1);
+  }
+
+  @Test
+  public void shouldRemoveLinksWhenOnlySubfield0Mapped() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00104nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, constructMappingDetails("0"), 0);
+  }
+
+  //negative tests
+  @Test
+  public void shouldThrowExceptionWhenInvalidEntityType() throws IOException {
+    var entityTypes = Lists.newArrayList(EntityType.values());
+    entityTypes.remove(MARC_BIBLIOGRAPHIC);
+    for (var entityType : entityTypes) {
+      testInvalidEntityType(entityType);
+    }
+  }
+
+  private void testInvalidEntityType(EntityType entityType) throws IOException {
+    var incomingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(""));
+    var existingRecord = new Record().withParsedRecord(new ParsedRecord().withContent(""));
+
+    var eventPayload = new DataImportEventPayload();
+    var context = new HashMap<String, String>();
+    context.put(entityType.value(), Json.encodePrettily(incomingRecord));
+    context.put("MATCHED_" + entityType.value(), Json.encodePrettily(existingRecord));
+    eventPayload.setContext(context);
+    var mappingProfile = new MappingProfile().withMappingDetails(new MappingDetail().withMarcMappingOption(UPDATE));
+
+    var exceptionThrown = false;
+    try {
+      marcBibRecordModifier.initialize(eventPayload, new MappingParameters(), mappingProfile, entityType, new InstanceLinkDtoCollection());
+    } catch (IllegalArgumentException ex) {
+      Assert.assertTrue(ex.getMessage().endsWith("support only " + MARC_BIBLIOGRAPHIC.value()));
+      exceptionThrown = true;
+    }
+    Assert.assertTrue("Exception not thrown for " + entityType.value(), exceptionThrown);
+  }
+
+  private void testMarcUpdating(String incomingParsedContent,
+                                String expectedParsedContent,
+                                int expectedLinksCount) throws IOException {
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, emptyList(), expectedLinksCount);
+  }
+
+  private void testMarcUpdating(String incomingParsedContent,
+                                String expectedParsedContent,
+                                List<MarcMappingDetail> mappingDetails,
+                                int expectedLinksCount) throws IOException {
+    var incomingRecord = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(incomingParsedContent));
+    var existingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\": \"ybp7406411\"},{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"}],\"ind1\": \" \",\"ind2\":\" \"}},{\"020\":{\"subfields\":[{\"b\":\"book\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var existingRecord = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(existingParsedContent));
+
+    var eventPayload = new DataImportEventPayload();
+    var context = new HashMap<String, String>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(incomingRecord));
+    context.put(MATCHED_MARC_BIB_KEY, Json.encodePrettily(existingRecord));
+    eventPayload.setContext(context);
+
+    var mappingProfile = new MappingProfile()
+      .withMappingDetails(new MappingDetail()
+        .withMarcMappingOption(UPDATE)
+        .withMarcMappingDetails(mappingDetails));
+    var mappingParameters = new MappingParameters();
+    var links = constructLinkCollection("020");
+
+    //when
+    marcBibRecordModifier.initialize(eventPayload, mappingParameters, mappingProfile, MARC_BIBLIOGRAPHIC, links);
+    marcBibRecordModifier.processUpdateMappingOption(mappingProfile.getMappingDetails().getMarcMappingDetails());
+    marcBibRecordModifier.getResult(eventPayload);
+    //then
+    var recordJson = eventPayload.getContext().get(MATCHED_MARC_BIB_KEY);
+    var actualRecord = mapper().readValue(recordJson, Record.class);
+    Assert.assertEquals(expectedParsedContent, actualRecord.getParsedRecord().getContent().toString());
+    Assert.assertEquals(expectedLinksCount, marcBibRecordModifier.getBibAuthorityLinksKept().size());
+  }
+
+  private InstanceLinkDtoCollection constructLinkCollection(String bibRecordTag) {
+    return new InstanceLinkDtoCollection()
+      .withLinks(singletonList(constructLink(bibRecordTag)));
+  }
+
+  private Link constructLink(String bibRecordTag) {
+    return new Link().withId(nextInt())
+      .withBibRecordTag(bibRecordTag)
+      .withBibRecordSubfields(singletonList("a"))
+      .withAuthorityId(UUID.randomUUID().toString())
+      .withInstanceId(UUID.randomUUID().toString())
+      .withAuthorityNaturalId("test");
+  }
+
+  private List<MarcMappingDetail> constructMappingDetails(String subfield) {
+    return singletonList(new MarcMappingDetail()
+      .withOrder(0)
+      .withField(new MarcField()
+        .withField("020")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfields(singletonList(
+          new MarcSubfield().withSubfield(subfield)))));
+  }
+}

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
@@ -44,8 +44,8 @@ import static org.folio.rest.jaxrs.model.MarcSubfield.Subaction.REPLACE;
 @RunWith(JUnit4.class)
 public class MarcRecordModifierTest {
 
-  private static final String MATCHED_MARC_BIB_KEY = "MATCHED_MARC_BIBLIOGRAPHIC";
-  private MarcRecordModifier marcRecordModifier = new MarcRecordModifier();
+  protected static final String MATCHED_MARC_BIB_KEY = "MATCHED_MARC_BIBLIOGRAPHIC";
+  protected MarcRecordModifier marcRecordModifier = new MarcRecordModifier();
 
   @Test(expected = IllegalArgumentException.class)
   public void shouldThrowExceptionWhenHasNoMarcRecord() throws IOException {


### PR DESCRIPTION
## Purpose
Use links data that come from mod-source-records-storage to update MARC bib record according to requirements
Delete links from links data if some of the cases occurred. Mod-source-record-storage will make a call to update links in mod-entities-links

## Approach
Implement custom MarcRecordModifier

## Learning
[MODDICORE-293](https://issues.folio.org/browse/MODDICORE-293)
