### PR TITLE
MODSOURCE-567 Revert generating srs schemas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,6 @@
               <sourcePaths>
                 <path>${basedir}/ramls/raml-storage/schemas/common/dataImportEventPayload.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/common/dataImportEventTypes.json</path>
-                <path>${basedir}/ramls/raml-storage/schemas/mod-source-record-storage/marcBibUpdate.json</path>
-                <path>${basedir}/ramls/raml-storage/schemas/mod-source-record-storage/linkUpdateReport.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-data-import-converter-storage/profileSnapshotWrapper.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-data-import-converter-storage/jobProfile.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-data-import-converter-storage/mappingProfile.json</path>


### PR DESCRIPTION
## Purpose
As mod-inventory use directly srs dependency then it's no need to generate schemas in processing-core

## Approach
-Revert generate srs schemas 
