### PR TITLE
[MODDICORE-303] Allow for mapping the vendor, material supplier, and access provider based on CODE in MARC record

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record
 * [MODDICORE-294](https://issues.folio.org/browse/MODDICORE-294) Add handling accepted values for repeatable fields
 * [MODDICORE-290](https://issues.folio.org/browse/MODDICORE-290) Extend Mapper for Order/OrderLines.
+* [MODDICORE-303](https://issues.folio.org/browse/MODDICORE-303) Allow for mapping the vendor, material supplier, and access provider based on CODE in MARC record.
 
 ## 2022-10-19 v3.5.1
 * [MODDICORE-281](https://issues.folio.org/browse/MODDICORE-281) Extend instance contributors schema with Authority ID

--- a/src/test/java/org/folio/processing/mapping/manager/TestOrder.java
+++ b/src/test/java/org/folio/processing/mapping/manager/TestOrder.java
@@ -1,0 +1,26 @@
+package org.folio.processing.mapping.manager;
+
+public class TestOrder {
+
+  private String id;
+  private String vendor;
+
+  TestOrder() {
+  }
+
+  public TestOrder(String id) {
+    this.id = id;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getVendor() {
+    return vendor;
+  }
+
+  public void setVendor(String vendor) {
+    this.vendor = vendor;
+  }
+}

--- a/src/test/java/org/folio/processing/mapping/manager/TestOrderWriter.java
+++ b/src/test/java/org/folio/processing/mapping/manager/TestOrderWriter.java
@@ -1,0 +1,67 @@
+package org.folio.processing.mapping.manager;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.folio.DataImportEventPayload;
+import org.folio.processing.mapping.mapper.writer.AbstractWriter;
+import org.folio.processing.value.BooleanValue;
+import org.folio.processing.value.ListValue;
+import org.folio.processing.value.MapValue;
+import org.folio.processing.value.RepeatableFieldValue;
+import org.folio.processing.value.StringValue;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.folio.rest.jaxrs.model.EntityType.ORDER;
+
+public class TestOrderWriter extends AbstractWriter {
+  private TestOrder order;
+
+  TestOrderWriter() {
+  }
+
+  @Override
+  public void initialize(DataImportEventPayload eventPayload) throws IOException {
+    if (eventPayload.getContext().containsKey(ORDER.value())) {
+      this.order = new ObjectMapper().readValue(eventPayload.getContext().get(ORDER.value()), TestOrder.class);
+    } else {
+      throw new IllegalArgumentException("Can not initialize OrderWriter, no order found in context");
+    }
+  }
+
+  @Override
+  public DataImportEventPayload getResult(DataImportEventPayload eventPayload) throws JsonProcessingException {
+    HashMap<String, String> context = eventPayload.getContext();
+    context.put(ORDER.value(), new ObjectMapper().writeValueAsString(this.order));
+    eventPayload.setContext(context);
+    return eventPayload;
+  }
+
+  @Override
+  protected void writeStringValue(String fieldPath, StringValue value) {
+    if (fieldPath.equals("order.po.vendor")) {
+      this.order.setVendor(value.getValue());
+    }
+  }
+
+  @Override
+  protected void writeListValue(String fieldPath, ListValue value) {
+
+  }
+
+  @Override
+  protected void writeObjectValue(String fieldPath, MapValue value) {
+
+  }
+
+  @Override
+  protected void writeRepeatableValue(String fieldPath, RepeatableFieldValue value) {
+
+  }
+
+  @Override
+  protected void writeBooleanValue(String fieldPath, BooleanValue value) {
+
+  }
+}

--- a/src/test/java/org/folio/processing/mapping/manager/TestOrderWriterFactory.java
+++ b/src/test/java/org/folio/processing/mapping/manager/TestOrderWriterFactory.java
@@ -1,0 +1,23 @@
+package org.folio.processing.mapping.manager;
+
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.processing.mapping.mapper.writer.WriterFactory;
+import org.folio.rest.jaxrs.model.EntityType;
+
+import static org.folio.rest.jaxrs.model.EntityType.ORDER;
+
+public class TestOrderWriterFactory implements WriterFactory {
+
+  TestOrderWriterFactory() {
+  }
+
+  @Override
+  public Writer createWriter() {
+    return new TestOrderWriter();
+  }
+
+  @Override
+  public boolean isEligibleForEntityType(EntityType entityType) {
+    return ORDER == entityType;
+  }
+}


### PR DESCRIPTION
## Purpose
Allow for mapping the vendor, material supplier, and access provider based on CODE in MARC record. For not CODE income values return blank value

## Approach
Added CODE (ID) of the organization to AcceptedValues of incoming vendor, material supplier or access provider, added functional that returns blanks if incoming value is not in acceptedValues (only for vendor, material supplier and access provider) 
Jira: https://issues.folio.org/browse/MODDICORE-303