### PR TITLE
Add uncontrolled subfields removal for linked fields on subfields removal

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.folio.DataImportEventPayload;
 import org.folio.InstanceLinkDtoCollection;
 import org.folio.Link;
@@ -71,6 +72,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
       fieldReplacement.getSubfields()
         .forEach(subfield ->
           updateUncontrolledSubfield(link, String.valueOf(subfield.getCode()), tmpFields, fieldToUpdate, fieldReplacement));
+      removeUncontrolledNotUpdatedSubfields(link, fieldToUpdate, fieldReplacement);
     } else {
       updateUncontrolledSubfield(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
     }
@@ -85,6 +87,15 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     }
 
     super.updateSubfields(subfieldCode, tmpFields, fieldToUpdate, fieldReplacement, false);
+  }
+
+  private void removeUncontrolledNotUpdatedSubfields(Link link, DataField fieldToUpdate, DataField fieldReplacement) {
+    fieldToUpdate.getSubfields().stream()
+      .filter(subfield -> !subfieldLinked(link, String.valueOf(subfield.getCode())))
+      .filter(subfield -> fieldReplacement.getSubfields().stream()
+        .noneMatch(subfieldReplacement -> subfield.getCode() == subfieldReplacement.getCode()))
+      .collect(Collectors.toList())
+      .forEach(fieldToUpdate::removeSubfield);
   }
 
   /**

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -194,6 +194,19 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
 
+  @Test
+  public void shouldRemoveUncontrolledSubfields() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"b\":\"tes\"},{\"0\":\"test\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00120nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), 1);
+  }
+
   //negative tests
   @Test
   public void shouldThrowExceptionWhenInvalidEntityType() throws IOException {
@@ -235,12 +248,21 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
                                 String expectedParsedContent,
                                 List<MarcMappingDetail> mappingDetails,
                                 int expectedLinksCount) throws IOException {
-    var incomingRecord = new Record().withParsedRecord(new ParsedRecord()
-      .withContent(incomingParsedContent));
     var existingParsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\": \"ybp7406411\"}," +
       "{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
       "{\"020\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
       "{\"020\":{\"subfields\":[{\"b\":\"book\"},{\"0\":\"test1\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, mappingDetails, expectedLinksCount);
+  }
+
+  private void testMarcUpdating(String existingParsedContent,
+                                String incomingParsedContent,
+                                String expectedParsedContent,
+                                List<MarcMappingDetail> mappingDetails,
+                                int expectedLinksCount) throws IOException {
+    var incomingRecord = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(incomingParsedContent));
     var existingRecord = new Record().withParsedRecord(new ParsedRecord()
       .withContent(existingParsedContent));
 


### PR DESCRIPTION
## Purpose
Add uncontrolled subfields removal for linked fields on subfields removal.

## Approach
Add uncontrolled subfields removal for linked fields on subfields removal.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
[MODDICORE-309](https://issues.folio.org/browse/MODDICORE-309)
