### PR TITLE
[MODDICORE-306] Order import: fix product identifier problem with ISBN field

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -281,7 +281,7 @@ public class MarcRecordReader implements Reader {
             ? BooleanValue.of(mappingRule.getBooleanFieldAction())
             : readSingleField(mappingRule, isRepeatableField);
 
-          if (value.getType() == MISSING && RequiredFields.isRequiredFieldName(mappingRule.getName())) {
+          if (value.getType() == MISSING && (mappingRule.getRequired() || RequiredFields.isRequiredFieldName(mappingRule.getName()))) {
             repeatableObjectItems.remove(repeatableObjectItems.size() - 1);
             break;
           } else if (shouldCreateItemPerRepeatedMarcField(value.getType(), mappingRule)) {


### PR DESCRIPTION
## Purpose
Validate mappingRule for the repeatable field by the "required" field (do not map if the required value is empty)

## Approach
Added new conditions and covered with tests

## Learning
Need to remove redundant "RequiredFields" enum and use the "required" field instead in further releases