### PR TITLE
MODDICORE-319 Modify linking check when $0 cannot be modified according to mapping

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -16,6 +16,7 @@ import org.folio.MappingProfile;
 import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
 import org.folio.rest.jaxrs.model.EntityType;
 import org.marc4j.marc.DataField;
+import org.marc4j.marc.Subfield;
 
 public class MarcBibRecordModifier extends MarcRecordModifier {
 
@@ -47,7 +48,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   protected boolean updateSubfields(String subfieldCode, List<DataField> tmpFields, DataField fieldToUpdate,
                                     DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
     var linkOptional = getLink(fieldToUpdate);
-    if (linkOptional.isPresent() && fieldsLinked(linkOptional.get(), fieldReplacement, fieldToUpdate)) {
+    if (linkOptional.isPresent() && fieldsLinked(subfieldCode.charAt(0), linkOptional.get(), fieldReplacement, fieldToUpdate)) {
       var link = linkOptional.get();
       bibAuthorityLinksKept.add(link);
       return updateUncontrolledSubfields(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
@@ -123,8 +124,13 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   /**
    * Indicates that incoming and existing fields hold the same link
    * */
-  private boolean fieldsLinked(Link link, DataField incomingField, DataField fieldToChange) {
-    var incomingSubfield0 = incomingField.getSubfield(SUBFIELD_0);
+  private boolean fieldsLinked(char subfieldCode, Link link, DataField incomingField, DataField fieldToChange) {
+    Subfield incomingSubfield0;
+    if (subfieldCode == ANY_CHAR || subfieldCode == SUBFIELD_0) {
+      incomingSubfield0 = incomingField.getSubfield(SUBFIELD_0);
+    } else {
+      incomingSubfield0 = fieldToChange.getSubfield(SUBFIELD_0);
+    }
     var existingSubfield0 = fieldToChange.getSubfield(SUBFIELD_0);
     return incomingSubfield0 != null
       && existingSubfield0 != null

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -76,7 +76,7 @@ public class MarcRecordModifier {
   private static final String TAG_199 = "199";
   private static final String TAG_999 = "999";
   private static final char INDICATOR_F = 'f';
-  private static final char ANY_CHAR = '*';
+  protected static final char ANY_CHAR = '*';
 
   private final MarcFactory marcFactory = MarcFactory.newInstance();
 

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -170,6 +170,20 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
   }
 
   @Test
+  public void shouldNotUpdateLinkedSubfieldWhenOnlySubfieldMappedAnd0Changed() throws IOException {
+    // given
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"020\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test updated\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
+      "{\"020\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00170nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"020\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"020\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"020\":{\"subfields\":[{\"b\":\"book\"},{\"0\":\"test1\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+
+    testMarcUpdating(incomingParsedContent, expectedParsedContent, constructMappingDetails("a"), 1);
+  }
+
+  @Test
   public void shouldRemoveLinksWhenOnlySubfield0MappedAndChanged() throws IOException {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +


### PR DESCRIPTION
## Purpose
Fix bug when: Link is removed from field when updating/deleting "$0" in linked "MARC bib" field upon data import if field mapping profile does not allow "$0" update

## Approach
Modify linking check to get $0 from existing record instead of incoming when $0 cannot be modified according to mapping

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
