### PR TITLE
MODDICORE-305 - Order import: fix product identifier mapping problem with multiple product ID TYPES

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -135,6 +135,10 @@ public class MarcRecordReader implements Reader {
   }
 
   private Value readSingleField(MappingRule ruleExpression, boolean isRepeatableField) {
+    if (ruleExpression.getValue() == null) {
+      return MissingValue.getInstance();
+    }
+
     String[] expressions = ruleExpression.getValue().split(EXPRESSIONS_DIVIDER);
     boolean arrayValue = ruleExpression.getPath().endsWith(EXPRESSIONS_ARRAY);
     List<String> resultList = new ArrayList<>();


### PR DESCRIPTION
## Purpose
to fix order line product identifiers field mapping when a mapping rule "value" field intermittently is not stored in a mapping profile for some of the product identifiers subfield (e.g qualifier)

## Approach
* add check for mapping rule "value" field is null to return MissingValue on processing such mapping rule
* add test

## Learning
[MODDICORE-305](https://issues.folio.org/browse/MODDICORE-305)
