### PR TITLE
MODDICORE-320: Changed instanceLink DTO according to recent changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
                 <path>${basedir}/ramls/raml-storage/schemas/dto/record.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/dto/edifactParsedContent.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/instanceLinkDtoCollection.json</path>
+                <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/linkingRuleDto.json</path>
                 <path>${basedir}/ramls/event.json</path>
                 <path>${basedir}/ramls/instance.json</path>
                 <path>${basedir}/ramls/holdings.json</path>
@@ -372,6 +373,14 @@
               io.vertx.core.logging.Log4j2LogDelegateFactory
             </vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>16</source>
+          <target>16</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Purpose
Update links interactions according to 'instance-authority-links' interface change to 2.0

## Approach
1. Update raml `InstanceLinkDtoCollection` dto with removing field/subfields, adding `linkingRuleId`
2. Add linking rules to constructor, they will be needed to identify linked subfields

## Learning
[https://issues.folio.org/browse/MODDICORE-320](https://issues.folio.org/browse/MODDICORE-320)
