### PR TITLE
MODDICORE-320: Changed instanceLink DTO according to recent changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -375,14 +375,6 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>16</source>
-          <target>16</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
                 <path>${basedir}/ramls/raml-storage/schemas/dto/record.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/dto/edifactParsedContent.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/instanceLinkDtoCollection.json</path>
+                <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/linkingRuleDto.json</path>
                 <path>${basedir}/ramls/event.json</path>
                 <path>${basedir}/ramls/instance.json</path>
                 <path>${basedir}/ramls/holdings.json</path>
@@ -372,6 +373,14 @@
               io.vertx.core.logging.Log4j2LogDelegateFactory
             </vertx.logger-delegate-factory-class-name>
           </systemPropertyVariables>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>16</source>
+          <target>16</target>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -206,9 +206,11 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     if (subfield0 == null) {
       return false;
     }
-
+    var rulesForTag = linkingRules.stream()
+                      .filter(r -> r.getBibField().equals(dataField.getTag()))
+                      .collect(Collectors.toList());
     return bibAuthorityLinksKept.stream()
-      .filter(link -> linkingRules.stream()
+      .filter(link -> rulesForTag.stream()
         .map(LinkingRuleDto::getId)
         .collect(Collectors.toList())
         .contains(link.getLinkingRuleId()))

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -55,8 +55,8 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
    */
   @Override
   protected boolean updateSubfields(String subfieldCode, List<DataField> tmpFields, DataField fieldToUpdate,
-    DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
-    var linkOptional = getLink(fieldReplacement);
+                                    DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
+    var linkOptional = getLink(fieldToUpdate);
     if (linkOptional.isPresent() && fieldsLinked(subfieldCode.charAt(0), linkOptional.get(), fieldReplacement, fieldToUpdate)) {
       var link = linkOptional.get();
       bibAuthorityLinksKept.add(link);
@@ -137,10 +137,10 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     }
 
     LinkingRuleDto dto = ruleDto.get();
-    List<String> bibRecordSubfields = dto.getBibRecordSubfields();
+    List<String> bibControlledSubfields = dto.getAuthoritySubfields();
     List<SubfieldModification> subfieldModifications = dto.getSubfieldModifications();
     List<String> modifiedBibSubfields = new ArrayList<>();
-    subfieldModifications.forEach(subfieldModification -> bibRecordSubfields.stream()
+    subfieldModifications.forEach(subfieldModification -> bibControlledSubfields.stream()
       .filter(s->subfieldModification.getSource().equals(s))
       .findFirst()
       .ifPresent(s -> modifiedBibSubfields.add(s.replace(subfieldModification.getSource(), subfieldModification.getTarget()))));

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -3,9 +3,7 @@ package org.folio.processing.mapping.mapper.writer.marc;
 import static java.util.Collections.emptyList;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -57,7 +55,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
 
   /**
    * Should call regular update subfield flow only for uncontrolled subfields
-   */
+   * */
   @Override
   protected boolean updateSubfields(String subfieldCode, List<DataField> tmpFields, DataField fieldToUpdate,
                                     DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
@@ -128,7 +126,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   private Optional<Link> getLink(DataField dataField) {
     return bibAuthorityLinks.stream()
       .filter(link -> linkingRules.stream()
-        .filter(linkingRuleDto -> linkingRuleDto.getBibRecordTag().equals(dataField.getTag()))
+        .filter(linkingRuleDto -> linkingRuleDto.getBibField().equals(dataField.getTag()))
         .map(LinkingRuleDto::getId)
         .collect(Collectors.toList())
         .contains(link.getLinkingRuleId()))

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -139,15 +139,17 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     LinkingRuleDto dto = ruleDto.get();
     List<String> bibControlledSubfields = dto.getAuthoritySubfields();
     List<SubfieldModification> subfieldModifications = dto.getSubfieldModifications();
-    List<String> modifiedBibSubfields = new ArrayList<>();
-    subfieldModifications.forEach(subfieldModification -> bibControlledSubfields.stream()
-      .filter(s->subfieldModification.getSource().equals(s))
-      .findFirst()
-      .ifPresent(s -> modifiedBibSubfields.add(s.replace(subfieldModification.getSource(), subfieldModification.getTarget()))));
 
-    return ruleDto.filter(linkingRuleDto -> linkingRuleDto.getAuthoritySubfields().contains(subfieldCode)
+    bibControlledSubfields = bibControlledSubfields.stream()
+      .map(s -> subfieldModifications.stream()
+        .filter(subfieldModification -> s.equals(subfieldModification.getSource()))
+        .map(SubfieldModification::getTarget)
+        .findFirst()
+        .orElse(s))
+      .collect(Collectors.toList());
+    return bibControlledSubfields.contains(subfieldCode)
       || subfieldCode.charAt(0) == SUBFIELD_0
-      || subfieldCode.charAt(0) == SUBFIELD_9).isPresent() || modifiedBibSubfields.contains(subfieldCode);
+      || subfieldCode.charAt(0) == SUBFIELD_9;
   }
 
   /**

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -126,11 +126,13 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
 
   private Optional<Link> getLink(DataField dataField) {
     return bibAuthorityLinks.stream()
-      .filter(link -> linkingRules.stream()
-        .filter(linkingRuleDto -> linkingRuleDto.getBibField().equals(dataField.getTag()))
-        .map(LinkingRuleDto::getId)
-        .collect(Collectors.toList())
-        .contains(link.getLinkingRuleId()))
+      .filter(link ->
+        linkingRules.stream()
+                    .filter(linkingRuleDto -> linkingRuleDto.getBibField().equals(dataField.getTag()))
+                    .map(LinkingRuleDto::getId)
+                    .collect(Collectors.toList())
+                    .contains(link.getLinkingRuleId())
+      )
       .filter(link -> {
         var sub9Matches = Optional.ofNullable(dataField.getSubfield(SUBFIELD_9))
           .map(subfield -> subfield.getData().equalsIgnoreCase(link.getAuthorityId()))

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -41,7 +41,7 @@ import org.junit.runners.JUnit4;
 public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
 
   private static final Integer LINKING_RULE_ID = 1;
-  public static final String SUB_FIELD_CODE_A = "a";
+  private static final String SUB_FIELD_CODE_A = "a";
   private final MarcBibRecordModifier marcBibRecordModifier;
 
   public MarcBibRecordModifierTest() {
@@ -356,7 +356,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
       + "{\"700\":{\"subfields\":[{\"a\":\"artistic\"},{\"b\":\"new subfield\"},{\"0\":\"test0\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
     testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), constructMarcFieldProtectionSettings("700", false),
-      emptyList(), 1, "700");
+      emptyList(), 2, "700", "700");
   }
 
   @Test

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -343,6 +343,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
       Assert.assertTrue(ex.getMessage().endsWith("support only " + MARC_BIBLIOGRAPHIC.value()));
       exceptionThrown = true;
     }
+
     Assert.assertTrue("Exception not thrown for " + entityType.value(), exceptionThrown);
   }
 

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -443,7 +443,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     var mappingParameters = new MappingParameters()
       .withMarcFieldProtectionSettings(systemProtectionSettings);
     var links = constructLinkCollection();
-    var linkingRules = constructLinkingRuleCollection("100");
+    var linkingRules = constructLinkingRuleCollection(linkedTag);
 
     //when
     marcBibRecordModifier.initialize(eventPayload, mappingParameters, mappingProfile, MARC_BIBLIOGRAPHIC, links, linkingRules);
@@ -459,7 +459,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
   private List<LinkingRuleDto> constructLinkingRuleCollection(String bibRecordTag) {
     LinkingRuleDto dto = new LinkingRuleDto();
     dto.setId(LINKING_RULE_ID);
-    dto.setBibRecordTag(bibRecordTag);
+    dto.setBibField(bibRecordTag);
     dto.setAuthoritySubfields(List.of(SUB_FIELD_CODE_A));
     return Collections.singletonList(dto);
   }

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -342,7 +343,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
       + "{\"700\":{\"subfields\":[{\"a\":\"artistic\"},{\"b\":\"new subfield\"},{\"0\":\"test0\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
     testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), constructMarcFieldProtectionSettings("700", false),
-      emptyList(), 2, "700", "700");
+      emptyList(), 1, "700");
   }
 
   @Test
@@ -471,7 +472,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
         .withMarcMappingDetails(mappingDetails));
     var mappingParameters = new MappingParameters()
       .withMarcFieldProtectionSettings(systemProtectionSettings);
-    var links = constructLinkCollection();
+    var links = constructLinkCollection(linkedTags);
     var linkingRules = constructLinkingRuleCollection(linkedTags);
 
     //when
@@ -486,11 +487,16 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
   }
 
   private List<LinkingRuleDto> constructLinkingRuleCollection(String[] bibRecordTag) {
-    LinkingRuleDto dto = new LinkingRuleDto();
-    dto.setId(LINKING_RULE_ID);
-    dto.setBibField(bibRecordTag[0]);
-    dto.setAuthoritySubfields(List.of(SUB_FIELD_CODE_A));
-    return Collections.singletonList(dto);
+    List<LinkingRuleDto> linkingRuleDtos = new ArrayList<>();
+    for (int i = 0; i < bibRecordTag.length; i++) {
+      LinkingRuleDto dto = new LinkingRuleDto();
+      dto.setId(i);
+      dto.setBibField(bibRecordTag[i]);
+      dto.setAuthoritySubfields(List.of(SUB_FIELD_CODE_A));
+      linkingRuleDtos.add(dto);
+    }
+
+    return linkingRuleDtos;
   }
 
   private List<MarcFieldProtectionSetting> constructMarcFieldProtectionSettings(String bibRecordTag, boolean override) {
@@ -504,18 +510,22 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
       .withData("*"));
   }
 
-  private InstanceLinkDtoCollection constructLinkCollection() {
+  private InstanceLinkDtoCollection constructLinkCollection(String... bibRecordTag) {
+    List<Link> links = new ArrayList<>();
+    for (int i = 0; i < bibRecordTag.length; i++) {
+      Link link = constructLink(i);
+      links.add(link);
+    }
     return new InstanceLinkDtoCollection()
-      .withLinks(singletonList(constructLink(0)));
+      .withLinks(links);
   }
 
   private Link constructLink(int id) {
-    return new Link().withId(nextInt())
+    return new Link().withId(id)
+      .withLinkingRuleId(id)
       .withAuthorityId(UUID.randomUUID().toString())
-
-      .withLinkingRuleId(LINKING_RULE_ID)
-      .withAuthorityNaturalId("test" + id)
-      .withAuthorityNaturalId("test");
+      .withInstanceId(UUID.randomUUID().toString())
+      .withAuthorityNaturalId("test" + id);
   }
 
   private List<MarcMappingDetail> constructMappingDetails(String subfield) {


### PR DESCRIPTION
## Purpose
Update links interactions according to 'instance-authority-links' interface change to 2.0

## Approach
Update raml InstanceLinkDtoCollection dto with removing field/subfields, adding linkingRuleId
Add linking rules to constructor, they will be needed to identify linked subfields

## Learning
[MODDICORE-320](https://issues.folio.org/browse/MODDICORE-320)
