### PR TITLE
MODDICORE-322 - Multiple 050 fields or subfields all map to Holdings/Item Call Number if Holdings/Item Mapping is set to 050$a or 050$a " " 050$b

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-03-xo v4.0.5-SNAPSHOT
+* [MODDICORE-322](https://issues.folio.org/browse/MODDICORE-322) Multiple 050 fields or subfields all map to Holdings/Item Call Number if Holdings/Item Mapping is set to 050$a or 050$a " " 050$b
+
 ## 2023-02-17 v4.0.0
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping. Expanded default mapper with alternative mapping logic
 * [MODSOURMAN-837](https://issues.folio.org/browse/MODSOURMAN-837) MARC bib - FOLIO instance mapping | Update default mapping to change how Relator term is populated on instance record

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -454,14 +454,6 @@ public class MarcRecordReader implements Reader {
     return value;
   }
 
-  private List<String> formatToIsoDate(List<String> stringsToFormat) {
-    List<String> formattedStrings = new ArrayList<>();
-    for (String stringToFormat : stringsToFormat) {
-      formattedStrings.add(formatToIsoDate(stringToFormat));
-    }
-    return formattedStrings;
-  }
-
   private String formatToIsoDate(String stringToFormat) {
     try {
       if (isNotEmpty(stringToFormat)) {

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -65,7 +65,7 @@ public class MarcRecordReaderUnitTest {
   private final String RECORD_WITH_SINGLE_028_FIELD = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"DXSB7-156\"},{\"b\":\"Decca\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
 
   private final String RECORD_WITH_THE_SAME_SUBFIELDS_IN_MULTIPLE_028_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aT90028\"},{\"b\":\"Verve\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aV-4061\"},{\"b\":\"Verve\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
-
+  private final String RECORD_WITH_MULTIPLE_SUBFIELDS_IN_MULTIPLE_050_FIELD = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\": [{\"001\": \"009221\"}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"Z2013.5.W6\"}, {\"b\": \"K46 2018\"}, {\"a\": \"PR1286.W6\"}]}}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"a2-val\"}, {\"b\": \"b2-val\"}, {\"a\": \"a2-val\"}]}}, {\"245\": \"American Bar Association journal\"}]}";
 
   private MappingContext mappingContext = new MappingContext();
 
@@ -1622,6 +1622,28 @@ public class MarcRecordReaderUnitTest {
     assertFalse(actualValue.getValue().isEmpty());
     assertEquals(ValueType.STRING, actualValue.getValue().get(0).get(productIdFieldPath).getType());
     assertEquals(ValueType.MISSING, actualValue.getValue().get(0).get(productQualifierFieldPath).getType());
+  }
+
+  @Test
+  public void shouldReturnStringValueFromFirstSubfieldOnlyOnProcessingNonRepeatableFieldRuleWhenFieldHasMultipleSpecifiedSubfields() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD_WITH_MULTIPLE_SUBFIELDS_IN_MULTIPLE_050_FIELD))).encode());
+    eventPayload.setContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    MappingRule callNumberRule = new MappingRule()
+      .withPath("holdings.callNumber")
+      .withEnabled("true")
+      .withValue("050$a");
+
+    Value value = reader.read(callNumberRule);
+
+    assertNotNull(value);
+    assertEquals(ValueType.STRING, value.getType());
+    assertEquals("Z2013.5.W6", value.getValue());
   }
 
 }


### PR DESCRIPTION
## Purpose
to fix call number field mapping for inventory holdings/item records when incoming MARC record contains multiple copies of the specified MARC field or multiple specified subfields in that MARC field.
For example when incoming record contains the following fields:
> 050 14 $aB3199.A33 $bP7613 2000a $aTA418.9.C6
> 050 14 $aZ5853.M38 $bG37 1993
> 
then for this specified mapping 050$a " " 050$b mapped "callNumber" field should contain: B3199.A33 P7613 2000a




## Approach
* change the approach of subfields data retrieving to get data for subfields with same name (code) separately per each subfield instead of getting it as concatenated value.
  For the simple filed rule return StringValue that contains data only from 1-st specified subfield.
* add test


## Learning
[MODDICORE-322](https://issues.folio.org/browse/MODDICORE-322)
https://wiki.folio.org/display/FOLIJET/Classification+and+Call+number+handling+in+Data+Import
