### PR TITLE
MODDICORE-335 Controlled subfields of Second repeatable and linked field could be overwritten by "Data import" update.

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/LinkFull.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/LinkFull.java
@@ -1,0 +1,28 @@
+package org.folio.processing.mapping.mapper.writer.marc;
+
+import java.util.List;
+import org.folio.Link;
+
+public class LinkFull {
+  private final Link link;
+  private final String bibTag;
+  private final List<String> bibSubfields;
+
+  public LinkFull(Link link, String bibTag, List<String> bibSubfields) {
+    this.link = link;
+    this.bibTag = bibTag;
+    this.bibSubfields = bibSubfields;
+  }
+
+  public Link getLink() {
+    return link;
+  }
+
+  public String getBibTag() {
+    return bibTag;
+  }
+
+  public List<String> getBibSubfields() {
+    return bibSubfields;
+  }
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifier.java
@@ -5,8 +5,8 @@ import static java.util.Collections.emptyList;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,12 +27,14 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   private static final char SUBFIELD_0 = '0';
   private static final char SUBFIELD_9 = '9';
 
-  private List<Link> bibAuthorityLinks = emptyList();
+  private List<LinkFull> bibAuthorityLinks = emptyList();
   private List<LinkingRuleDto> linkingRules = emptyList();
-  private final Set<Link> bibAuthorityLinksKept = new HashSet<>();
+  private final Set<LinkFull> bibAuthorityLinksKept = new HashSet<>();
 
   public List<Link> getBibAuthorityLinksKept() {
-    return new LinkedList<>(bibAuthorityLinksKept);
+    return bibAuthorityLinksKept.stream()
+      .map(LinkFull::getLink)
+      .collect(Collectors.toList());
   }
 
   public void initialize(DataImportEventPayload eventPayload, MappingParameters mappingParameters,
@@ -43,7 +45,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     if (links == null || links.getLinks() == null) {
       return;
     }
-    bibAuthorityLinks = links.getLinks();
+    bibAuthorityLinks = buildFullLinks(links.getLinks(), linkingRules);
     this.linkingRules = linkingRules;
   }
 
@@ -59,7 +61,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   protected boolean updateSubfields(String subfieldCode, List<DataField> tmpFields, DataField fieldToUpdate,
                                     DataField fieldReplacement, boolean ifNewDataShouldBeAdded) {
     var linkOptional = getLink(fieldToUpdate);
-    if (linkOptional.isPresent() && fieldsLinked(subfieldCode.charAt(0), linkOptional.get(), fieldReplacement, fieldToUpdate)) {
+    if (linkOptional.isPresent() && fieldsLinked(subfieldCode.charAt(0), linkOptional.get().getLink(), fieldReplacement, fieldToUpdate)) {
       var link = linkOptional.get();
       bibAuthorityLinksKept.add(link);
       return updateUncontrolledSubfields(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
@@ -76,17 +78,64 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
   }
 
   @Override
+  protected void clearDataField(DataField updatedField) {
+    removeSubfield9(updatedField);
+    super.clearDataField(updatedField);
+  }
+
+  @Override
   protected boolean unUpdatedFieldShouldBeRemoved(DataField dataField) {
     return super.unUpdatedFieldShouldBeRemoved(dataField) && !fieldLinked(dataField);
   }
 
-  private boolean updateUncontrolledSubfields(Link link, String subfieldCode, List<DataField> tmpFields,
+  @Override
+  protected boolean fieldsDeepMatch(List<DataField> fieldReplacements, List<DataField> fieldsToUpdate,
+                                    DataField fieldReplacement, DataField fieldToUpdate) {
+    if (isNonRepeatableField(fieldReplacement)) {
+      return true;
+    }
+
+    var incomingSubfields0 = fieldReplacement.getSubfields(SUBFIELD_0).stream()
+      .map(Subfield::getData)
+      .collect(Collectors.toList());
+    // only one subfield $0 extracted from existing because linked field can only have single $0
+    var existingSubfield0 = fieldToUpdate.getSubfield(SUBFIELD_0);
+
+    // both absent or both have equal $0
+    if (incomingSubfields0.isEmpty() && existingSubfield0 == null
+      || existingSubfield0 != null && incomingSubfields0.contains(existingSubfield0.getData())) {
+      return true;
+    }
+
+    //if incoming linked to some other existing
+    var incomingFieldLinked = fieldsToUpdate.stream()
+      .anyMatch(dataField -> dataField.getTag().equals(fieldReplacement.getTag())
+        && dataField.getSubfield(SUBFIELD_0) != null
+        && incomingSubfields0.contains(dataField.getSubfield(SUBFIELD_0).getData()));
+
+    if (existingSubfield0 == null) {
+      return !incomingFieldLinked;
+    }
+
+    //if existing linked to some other incoming
+    var existingFieldLinked = fieldReplacements.stream()
+      .anyMatch(dataField -> dataField.getTag().equals(fieldToUpdate.getTag())
+        && dataField.getSubfield(SUBFIELD_0) != null
+        && existingSubfield0.getData().equals(dataField.getSubfield(SUBFIELD_0).getData()));
+
+    return !(incomingFieldLinked || existingFieldLinked);
+  }
+
+  private boolean updateUncontrolledSubfields(LinkFull link, String subfieldCode, List<DataField> tmpFields,
                                               DataField fieldToUpdate, DataField fieldReplacement) {
     if (subfieldCode.equals(ANY_STRING)) {
       fieldReplacement.getSubfields()
         .forEach(subfield ->
           updateUncontrolledSubfield(link, String.valueOf(subfield.getCode()), tmpFields, fieldToUpdate, fieldReplacement));
       removeUncontrolledNotUpdatedSubfields(link, fieldToUpdate, fieldReplacement);
+      fieldReplacement.getSubfields().clear();
+      fieldReplacement.getSubfields().addAll(fieldToUpdate.getSubfields());
+      return super.updateSubfields(subfieldCode, tmpFields, fieldToUpdate, fieldReplacement, true);
     } else {
       updateUncontrolledSubfield(link, subfieldCode, tmpFields, fieldToUpdate, fieldReplacement);
     }
@@ -94,7 +143,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     return false;
   }
 
-  private void updateUncontrolledSubfield(Link link, String subfieldCode, List<DataField> tmpFields,
+  private void updateUncontrolledSubfield(LinkFull link, String subfieldCode, List<DataField> tmpFields,
                                           DataField fieldToUpdate, DataField fieldReplacement) {
     if (subfieldLinked(link, subfieldCode)) {
       return;
@@ -103,7 +152,7 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     super.updateSubfields(subfieldCode, tmpFields, fieldToUpdate, fieldReplacement, false);
   }
 
-  private void removeUncontrolledNotUpdatedSubfields(Link link, DataField fieldToUpdate, DataField fieldReplacement) {
+  private void removeUncontrolledNotUpdatedSubfields(LinkFull link, DataField fieldToUpdate, DataField fieldReplacement) {
     fieldToUpdate.getSubfields().stream()
       .filter(subfield -> !subfieldLinked(link, String.valueOf(subfield.getCode())))
       .filter(subfield -> fieldReplacement.getSubfields().stream()
@@ -118,49 +167,30 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
    * It also should be removed if $9 is not in mapping details (and subfield is not '*') but field is unlinked.
    * */
   private void removeSubfield9(DataField fieldToUpdate, DataField fieldReplacement) {
-    fieldToUpdate.getSubfields().removeIf(subfield -> subfield.getCode() == SUBFIELD_9);
-    fieldReplacement.getSubfields().removeIf(subfield -> subfield.getCode() == SUBFIELD_9);
+    removeSubfield9(fieldToUpdate);
+    removeSubfield9(fieldReplacement);
+  }
+  private void removeSubfield9(DataField dataField) {
+    dataField.getSubfields().removeIf(subfield -> subfield.getCode() == SUBFIELD_9);
   }
 
-  private Optional<Link> getLink(DataField dataField) {
+  private Optional<LinkFull> getLink(DataField dataField) {
     return bibAuthorityLinks.stream()
-      .filter(link ->
-        linkingRules.stream()
-                    .filter(linkingRuleDto -> linkingRuleDto.getBibField().equals(dataField.getTag()))
-                    .map(LinkingRuleDto::getId)
-                    .collect(Collectors.toList())
-                    .contains(link.getLinkingRuleId())
-      )
+      .filter(link -> link.getBibTag().equals(dataField.getTag()))
       .filter(link -> {
         var sub9Matches = Optional.ofNullable(dataField.getSubfield(SUBFIELD_9))
-          .map(subfield -> subfield.getData().equalsIgnoreCase(link.getAuthorityId()))
+          .map(subfield -> subfield.getData().equalsIgnoreCase(link.getLink().getAuthorityId()))
           .orElse(false);
         var sub0Matches = Optional.ofNullable(dataField.getSubfield(SUBFIELD_0))
-          .map(subfield -> StringUtils.endsWithIgnoreCase(subfield.getData(), link.getAuthorityNaturalId()))
+          .map(subfield -> StringUtils.endsWithIgnoreCase(subfield.getData(), link.getLink().getAuthorityNaturalId()))
           .orElse(false);
         return sub9Matches || sub0Matches;
       })
       .findFirst();
   }
 
-  private boolean subfieldLinked(Link link, String subfieldCode) {
-    Optional<LinkingRuleDto> ruleDto = linkingRules.stream().filter(r -> r.getId().equals(link.getLinkingRuleId())).findFirst();
-    if (ruleDto.isEmpty()) {
-      return false;
-    }
-
-    LinkingRuleDto dto = ruleDto.get();
-    List<String> bibControlledSubfields = dto.getAuthoritySubfields();
-    List<SubfieldModification> subfieldModifications = dto.getSubfieldModifications();
-
-    bibControlledSubfields = bibControlledSubfields.stream()
-      .map(s -> subfieldModifications.stream()
-        .filter(subfieldModification -> s.equals(subfieldModification.getSource()))
-        .map(SubfieldModification::getTarget)
-        .findFirst()
-        .orElse(s))
-      .collect(Collectors.toList());
-    return bibControlledSubfields.contains(subfieldCode)
+  private boolean subfieldLinked(LinkFull link, String subfieldCode) {
+    return link.getBibSubfields().contains(subfieldCode)
       || subfieldCode.charAt(0) == SUBFIELD_0
       || subfieldCode.charAt(0) == SUBFIELD_9;
   }
@@ -210,15 +240,10 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
     if (subfield0 == null) {
       return false;
     }
-    var rulesForTag = linkingRules.stream()
-                      .filter(r -> r.getBibField().equals(dataField.getTag()))
-                      .collect(Collectors.toList());
+
     return bibAuthorityLinksKept.stream()
-      .filter(link -> rulesForTag.stream()
-        .map(LinkingRuleDto::getId)
-        .collect(Collectors.toList())
-        .contains(link.getLinkingRuleId()))
-      .anyMatch(link -> subfield0.getData().endsWith(link.getAuthorityNaturalId()));
+      .filter(link -> link.getBibTag().equals(dataField.getTag()))
+      .anyMatch(link -> subfield0.getData().endsWith(link.getLink().getAuthorityNaturalId()));
   }
 
   private void validateEntityType(EntityType entityType) {
@@ -226,5 +251,31 @@ public class MarcBibRecordModifier extends MarcRecordModifier {
       throw new IllegalArgumentException(this.getClass().getSimpleName() + " support only "
         + EntityType.MARC_BIBLIOGRAPHIC.value());
     }
+  }
+
+  private List<LinkFull> buildFullLinks(List<Link> links, List<LinkingRuleDto> linkingRules) {
+    return links.stream()
+      .map(link -> {
+        var linkingRule = linkingRules.stream()
+          .filter(linkingRuleDto -> linkingRuleDto.getId().equals(link.getLinkingRuleId()))
+          .findFirst();
+
+        if (linkingRule.isEmpty()) {
+          return null;
+        }
+
+        var subfieldModifications = linkingRule.get().getSubfieldModifications();
+        var bibSubfields = linkingRule.get().getAuthoritySubfields().stream()
+          .map(s -> subfieldModifications.stream()
+            .filter(subfieldModification -> s.equals(subfieldModification.getSource()))
+            .map(SubfieldModification::getTarget)
+            .findFirst()
+            .orElse(s))
+          .collect(Collectors.toList());
+
+        return new LinkFull(link, linkingRule.get().getBibField(), bibSubfields);
+      })
+      .filter(Objects::nonNull)
+      .collect(Collectors.toList());
   }
 }

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -28,6 +28,7 @@ import org.folio.rest.jaxrs.model.MarcFieldProtectionSetting;
 import org.folio.rest.jaxrs.model.MarcMappingDetail;
 import org.folio.rest.jaxrs.model.MarcSubfield;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -56,14 +57,16 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
   @Test
   public void shouldRemoveLinksOnRepeatableLinkedFieldRemoval() throws IOException {
     // given
-    var incomingParsedContent = "{\"leader\":\"00070nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book\"},{\"0\":\"test1\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
-    var expectedParsedContent = "{\"leader\":\"00099nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book\"},{\"0\":\"test1\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00070nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
-    testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
+      emptyList(), emptyList(), emptyList(), 0, "700");
   }
 
   @Test
@@ -71,10 +74,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test0\"},{\"9\":\"aabf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00150nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
@@ -84,10 +87,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"aaaf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00150nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
@@ -97,10 +100,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00150nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
@@ -110,10 +113,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00113nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
   }
@@ -123,10 +126,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"},{\"0\":\"test2\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00127nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"},{\"0\":\"test2\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
   }
@@ -136,11 +139,11 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test0\"},{\"0\":\"test2\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00150nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},"
       + "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},"
-      + "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}"
-      + ",{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      + "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}},"
+      + "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
@@ -150,11 +153,11 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test2\"},{\"0\":\"test0\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00150nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},"
       + "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},"
-      + "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}"
-      + ",{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      + "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}},"
+      + "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 1);
   }
@@ -164,10 +167,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00120nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
   }
@@ -177,10 +180,10 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00113nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
   }
@@ -190,12 +193,154 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00120nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
 
     testMarcUpdating(incomingParsedContent, expectedParsedContent, 0);
+  }
+
+  @Test
+  public void shouldNotUpdateLinkedSubfield9WIthAnotherAlsoLinked() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"b\":\"tes\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
+      "{\"245\":{\"subfields\":[{\"b\":\"book\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
+      "{\"245\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"0\":\"test1\"},{\"9\":\"(AuCNLDY)3360609\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00218nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"245\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), emptyList(), emptyList(), 2, "100", "700");
+  }
+
+  @Test
+  public void shouldUnlinkAndRemoveAll9SubfieldsWhenSubfield0ChangeInRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"b\":\"tes\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"b\":\"tes\"},{\"0\":\"test0\"}," +
+      "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"b\":\"tes\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"}," +
+      "{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"},{\"9\":\"aaaf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}," +
+      "{\"9\":\"aaa\"},{\"9\":\"bbb\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00111nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaaaa\"},{\"b\":\"tes\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), emptyList(), emptyList(), 0, "700");
+  }
+
+  //repeatable linked cases
+  @Test
+  public void shouldNotUpdateLinkedSubfield9InRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"(AuCNLDY)3360609\"}],\"ind1\": \" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00142nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent, emptyList(), emptyList(), emptyList(), 1, "700");
+  }
+
+  @Test
+  public void shouldHandleMultipleSubfield0ChangeAndSomeLinksKeptInRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test3\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test4\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"},{\"9\":\"edbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test5\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test3\"},{\"9\":\"fdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00282nam  22000971a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"aaaa\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test4\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test5\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test3\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
+      emptyList(), emptyList(), emptyList(), 2, "700", "700", "700", "700");
+  }
+
+  @Test
+  public void shouldHandleSubfield0ChangeAndSomeLinksKeptInRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan1\"},{\"0\":\"test1\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00214nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan1\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
+      emptyList(), emptyList(), emptyList(), 2, "700", "700", "700");
+  }
+
+  @Test
+  public void shouldHandleSubfield0ChangeAndSomeLinksKeptWithShuffleInRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John1\"},{\"0\":\"test1\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00214nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John1\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
+      emptyList(), emptyList(), emptyList(), 2, "700", "700", "700");
+  }
+
+  @Test
+  @Ignore("Requirements unknown. Leave as is until clarified.")
+  public void shouldHandleSubfield0ChangeWithShuffleInRepeatable() throws IOException {
+    // given
+    var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John\"},{\"0\":\"test0\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny\"},{\"0\":\"test1\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test2\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John1\"},{\"0\":\"test1\"},{\"9\":\"adbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan1\"},{\"0\":\"test0\"},{\"9\":\"cdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny1\"},{\"0\":\"test2\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    var expectedParsedContent = "{\"leader\":\"00251nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"John1\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonatan1\"},{\"0\":\"test0\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
+      "{\"700\":{\"subfields\":[{\"a\":\"Jonny1\"},{\"0\":\"test2\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+    testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
+      emptyList(), emptyList(), emptyList(), 0, "700", "700", "700");
   }
 
   //custom mapping details tests
@@ -204,7 +349,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00171nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test0\"},{\"9\":\"bdbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
       "{\"110\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
@@ -218,7 +363,7 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
     // given
     var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic updated\"},{\"0\":\"test1\"}],\"ind1\": \" \",\"ind2\":\" \"}}," +
-      "{\"100\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
+      "{\"110\":{\"subfields\":[{\"b\":\"book updated\"}],\"ind1\":\"0\",\"ind2\":\"0\"}}]}";
     var expectedParsedContent = "{\"leader\":\"00133nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
       "{\"100\":{\"subfields\":[{\"a\":\"electronic\"},{\"0\":\"test1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +
       "{\"110\":{\"subfields\":[{\"b\":\"book1\"}],\"ind1\":\" \",\"ind2\":\" \"}}," +


### PR DESCRIPTION
## Purpose
Fix handling links in repeatable fields. Fix $9 subfield removal on linkable (not linked) repeatable fields.

## Approach
- Fix handling links in repeatable fields
- Fix $9 subfield removal on linkable (not linked) repeatable fields
- Refactor links/linking rules interaction
- Fix repeatable/single field logic in tests

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
[MODDICORE-335](https://issues.folio.org/browse/MODDICORE-335)
