### PR TITLE
[MODDICORE-90] Change Mapper to allow mapping of multiple Items

### DIFF
--- a/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
@@ -1,6 +1,7 @@
 package org.folio.processing.mapping.mapper;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.DataImportEventPayload;
@@ -8,6 +9,7 @@ import org.folio.MappingProfile;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.writer.Writer;
 import org.folio.processing.value.Value;
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingRule;
 
 import java.io.IOException;
@@ -110,5 +112,23 @@ public interface Mapper {
     }
     DataImportEventPayload resultedPayload = writer.getResult(eventPayload);
     return new JsonObject(resultedPayload.getContext().get(entityType));
+  }
+
+  default void adjustContextToContainEntitiesAsJsonObject(DataImportEventPayload eventPayload, EntityType entityType) {
+    if (isJsonArray(eventPayload.getContext().get(entityType.value()))) {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(entityType.value()));
+      if (holdings.size() > 0) {
+        eventPayload.getContext().put(entityType.value(), holdings.getJsonObject(0).encode());
+      }
+    }
+  }
+
+  default boolean isJsonArray(String jsonArrayAsString) {
+    try {
+      new JsonArray(jsonArrayAsString);
+      return true;
+    } catch (DecodeException e) {
+      return false;
+    }
   }
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
@@ -116,9 +116,9 @@ public interface Mapper {
 
   default void adjustContextToContainEntitiesAsJsonObject(DataImportEventPayload eventPayload, EntityType entityType) {
     if (isJsonArray(eventPayload.getContext().get(entityType.value()))) {
-      JsonArray holdings = new JsonArray(eventPayload.getContext().get(entityType.value()));
-      if (holdings.size() > 0) {
-        eventPayload.getContext().put(entityType.value(), holdings.getJsonObject(0).encode());
+      JsonArray entities = new JsonArray(eventPayload.getContext().get(entityType.value()));
+      if (entities.size() > 0) {
+        eventPayload.getContext().put(entityType.value(), entities.getJsonObject(0).encode());
       } else {
         eventPayload.getContext().put(entityType.value(), EMPTY_JSON);
       }

--- a/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
@@ -119,6 +119,8 @@ public interface Mapper {
       JsonArray holdings = new JsonArray(eventPayload.getContext().get(entityType.value()));
       if (holdings.size() > 0) {
         eventPayload.getContext().put(entityType.value(), holdings.getJsonObject(0).encode());
+      } else {
+        eventPayload.getContext().put(entityType.value(), EMPTY_JSON);
       }
     }
   }

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -13,6 +13,7 @@ import org.folio.processing.mapping.mapper.Mapper;
 import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingRule;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class HoldingsMapper implements Mapper {
   private static final String PERMANENT_LOCATION_ID = "permanentLocationId";
   private static final String HOLDINGS = "HOLDINGS";
   private static final String HOLDINGS_IDENTIFIERS = "HOLDINGS_IDENTIFIERS";
-  private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
+  public static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
   private Reader reader;
   private Writer writer;
 
@@ -60,7 +61,7 @@ public class HoldingsMapper implements Mapper {
     Optional<MappingRule> permanentLocationMappingRule = mappingRules.stream().filter(rule -> rule.getName().equals(PERMANENT_LOCATION_ID)).findFirst();
 
     if (permanentLocationMappingRule.isEmpty() || !isStaredWithMarcField(permanentLocationMappingRule.get().getValue())) {
-      adjustContextToContainHoldingsAsJsonObject(eventPayload);
+      adjustContextToContainEntitiesAsJsonObject(eventPayload, EntityType.HOLDINGS);
       writer.initialize(eventPayload);
       holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
     } else {
@@ -87,24 +88,6 @@ public class HoldingsMapper implements Mapper {
       reader.initialize(eventPayload, mappingContext);
       writer.initialize(eventPayload);
       holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
-    }
-  }
-
-  private void adjustContextToContainHoldingsAsJsonObject(DataImportEventPayload eventPayload) {
-    if (isJsonArray(eventPayload.getContext().get(HOLDINGS))) {
-      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS));
-      if (holdings.size() > 0) {
-        eventPayload.getContext().put(HOLDINGS, holdings.getJsonObject(0).encode());
-      }
-    }
-  }
-
-  private boolean isJsonArray(String jsonArrayAsString) {
-    try {
-      new JsonArray(jsonArrayAsString);
-      return true;
-    } catch (DecodeException e) {
-      return false;
     }
   }
 

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -23,13 +23,13 @@ import java.util.Optional;
 
 import static org.folio.processing.mapping.mapper.reader.record.marc.MarcRecordReader.MARC_PATTERN;
 import static org.folio.processing.mapping.mapper.reader.record.marc.MarcRecordReader.WHITESPACE_DIVIDER;
+import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
 
 public class HoldingsMapper implements Mapper {
   private static final Logger LOGGER = LogManager.getLogger(HoldingsMapper.class);
   private static final String PERMANENT_LOCATION_ID = "permanentLocationId";
-  private static final String HOLDINGS = "HOLDINGS";
   private static final String HOLDINGS_IDENTIFIERS = "HOLDINGS_IDENTIFIERS";
-  private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
+  public static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
   private Reader reader;
   private Writer writer;
 
@@ -59,17 +59,17 @@ public class HoldingsMapper implements Mapper {
     Optional<MappingRule> permanentLocationMappingRule = mappingRules.stream().filter(rule -> rule.getName().equals(PERMANENT_LOCATION_ID)).findFirst();
 
     if (permanentLocationMappingRule.isEmpty() || !isStaredWithMarcField(permanentLocationMappingRule.get().getValue())) {
-      holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
+      holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS.value()));
     } else {
       String expressionPart = permanentLocationMappingRule.get().getValue().split(WHITESPACE_DIVIDER)[0];
       String marcField = retrieveMarcFieldName(expressionPart)
         .orElseThrow(() -> new RuntimeException(String.format("Invalid  value for mapping rule: %s", PERMANENT_LOCATION_ID)));
       eventPayload.getContext().put(MULTIPLE_HOLDINGS_FIELD, marcField);
 
-      holdings = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, HOLDINGS, marcField);
+      holdings = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, HOLDINGS.value(), marcField);
     }
     eventPayload.getContext().put(HOLDINGS_IDENTIFIERS, Json.encode(getPermanentLocationsFromHoldings(holdings)));
-    eventPayload.getContext().put(HOLDINGS, Json.encode(distinctHoldingsByPermanentLocation(holdings)));
+    eventPayload.getContext().put(HOLDINGS.value(), Json.encode(distinctHoldingsByPermanentLocation(holdings)));
     return eventPayload;
   }
 

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
@@ -1,0 +1,64 @@
+package org.folio.processing.mapping.mapper.mappers;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.processing.exceptions.MappingException;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.MappingContext;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.MappingRule;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.folio.processing.mapping.mapper.mappers.HoldingsMapper.MULTIPLE_HOLDINGS_FIELD;
+import static org.folio.rest.jaxrs.model.EntityType.ITEM;
+
+public class ItemMapper implements Mapper {
+  private static final Logger LOGGER = LogManager.getLogger(ItemMapper.class);
+  private Reader reader;
+  private Writer writer;
+
+  public ItemMapper(Reader reader, Writer writer) {
+    this.reader = reader;
+    this.writer = writer;
+  }
+
+  @Override
+  public DataImportEventPayload map(MappingProfile profile, DataImportEventPayload eventPayload, MappingContext mappingContext) {
+    try {
+      initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+      if (ifProfileIsInvalid(profile)) {
+        return eventPayload;
+      }
+      return executeMultipleItemsLogic(eventPayload, profile, mappingContext);
+    } catch (IOException e) {
+      LOGGER.warn("map:: Failed to perform Items mapping", e);
+      throw new MappingException(e);
+    }
+  }
+
+  private DataImportEventPayload executeMultipleItemsLogic(DataImportEventPayload eventPayload, MappingProfile profile,
+                                                           MappingContext mappingContext) throws IOException {
+    HashMap<String, String> payloadContext = eventPayload.getContext();
+    List<MappingRule> mappingRules = profile.getMappingDetails().getMappingFields();
+    JsonArray items = new JsonArray();
+    String marcField = payloadContext.get(MULTIPLE_HOLDINGS_FIELD);
+
+    if (marcField == null) {
+      items.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, ITEM.value()));
+    } else {
+      items = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, ITEM.value(), marcField);
+      payloadContext.remove(MULTIPLE_HOLDINGS_FIELD);
+    }
+
+    payloadContext.put(ITEM.value(), Json.encode(items));
+    return eventPayload;
+  }
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
@@ -22,8 +22,8 @@ import static org.folio.rest.jaxrs.model.EntityType.ITEM;
 
 public class ItemMapper implements Mapper {
   private static final Logger LOGGER = LogManager.getLogger(ItemMapper.class);
-  private Reader reader;
-  private Writer writer;
+  private final Reader reader;
+  private final Writer writer;
 
   public ItemMapper(Reader reader, Writer writer) {
     this.reader = reader;
@@ -52,6 +52,8 @@ public class ItemMapper implements Mapper {
     String marcField = payloadContext.get(MULTIPLE_HOLDINGS_FIELD);
 
     if (marcField == null) {
+      adjustContextToContainEntitiesAsJsonObject(eventPayload, ITEM);
+      writer.initialize(eventPayload);
       items.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, ITEM.value()));
     } else {
       items = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, ITEM.value(), marcField);

--- a/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
@@ -41,7 +41,7 @@ public class ItemMapperTest {
     Record record = new Record().withParsedRecord(new ParsedRecord()
       .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
     HashMap<String, String> context = new HashMap<>();
-    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(ITEM.value(), new JsonArray().toString());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
     eventPayload.setContext(context);
 
@@ -83,9 +83,9 @@ public class ItemMapperTest {
     Record record = new Record().withParsedRecord(new ParsedRecord()
       .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
     HashMap<String, String> context = new HashMap<>();
+    UUID itemId = UUID.randomUUID();
     JsonArray itemsAsJson = new JsonArray(List.of(
-      new JsonObject()
-        .put("id", UUID.randomUUID())));
+      new JsonObject().put("item", new JsonObject().put("id", itemId))));
 
     context.put(ITEM.value(), itemsAsJson.encode());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
@@ -121,6 +121,7 @@ public class ItemMapperTest {
     JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
     assertEquals(1, items.size());
     assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+    assertEquals(itemId.toString(), items.getJsonObject(0).getJsonObject("item").getString("id"));
   }
 
   @Test
@@ -129,7 +130,7 @@ public class ItemMapperTest {
     Record record = new Record().withParsedRecord(new ParsedRecord()
       .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
     HashMap<String, String> context = new HashMap<>();
-    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(ITEM.value(), new JsonArray().toString());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
     context.put(MULTIPLE_HOLDINGS_FIELD, "945");
     eventPayload.setContext(context);
@@ -206,7 +207,7 @@ public class ItemMapperTest {
     Record record = new Record().withParsedRecord(new ParsedRecord()
       .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
     HashMap<String, String> context = new HashMap<>();
-    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(ITEM.value(), new JsonArray().toString());
     context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
     eventPayload.setContext(context);
 
@@ -230,7 +231,7 @@ public class ItemMapperTest {
     DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
     assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(mappedPayload.getContext().get(ITEM.value()));
-    JsonObject items = new JsonObject(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
     assertEquals(0, items.size());
   }
 }

--- a/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
@@ -1,0 +1,190 @@
+package org.folio.processing.mapping.mapper;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.ParsedRecord;
+import org.folio.Record;
+import org.folio.processing.mapping.mapper.mappers.ItemMapper;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
+import org.folio.processing.mapping.mapper.writer.common.JsonBasedWriter;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MappingRule;
+import org.folio.rest.jaxrs.model.RepeatableSubfieldMapping;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.processing.mapping.mapper.mappers.HoldingsMapper.MULTIPLE_HOLDINGS_FIELD;
+import static org.folio.rest.jaxrs.model.EntityType.ITEM;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(JUnit4.class)
+public class ItemMapperTest {
+  private final String PARSED_CONTENT_WITH_MULTIPLE_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"944\":{\"subfields\":[{\"s\":\"testCode2\"}],\"ind1\":\" \",\"ind2\":\" \"}}, {\"945\":{\"subfields\":[{\"a\":\"E\"}, {\"b\":\"123\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"KU/CC/DI/A\"}, {\"b\":\"1234\"}, {\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+  @Test
+  public void shouldCreateOneItem() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("item")
+      .withRecordType(ITEM)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("barcode")
+          .withEnabled("true")
+          .withPath("item.barcode")
+          .withValue("\"123\"")));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(1, items.size());
+    assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+  }
+
+  @Test
+  public void shouldCreateMultipleItemPerHoldingsPermanentLocationFields() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    context.put(MULTIPLE_HOLDINGS_FIELD, "945");
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("item")
+      .withRecordType(ITEM)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+        .withName("barcode")
+        .withEnabled("true")
+        .withPath("item.barcode")
+        .withValue("945$b"),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("item.statisticalCodeIds[]")
+          .withValue("")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+          .withSubfields(List.of(
+            new RepeatableSubfieldMapping()
+              .withOrder(0)
+              .withPath("item.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("item.statisticalCodeIds[]")
+                .withValue("\"Testing\""))),
+            new RepeatableSubfieldMapping()
+              .withOrder(1)
+              .withPath("item.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("item.statisticalCodeIds[]")
+                .withValue("945$s; else 944$s")))))));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(3, items.size());
+    assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+    assertEquals("1234", items.getJsonObject(1).getJsonObject("item").getString("barcode"));
+    assertNull(items.getJsonObject(2).getJsonObject("item").getString("barcode"));
+
+    assertEquals("Testing", items.getJsonObject(0).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode", items.getJsonObject(0).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("Testing", items.getJsonObject(1).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode2", items.getJsonObject(1).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("Testing", items.getJsonObject(2).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode2", items.getJsonObject(2).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+  }
+
+  @Test
+  public void shouldNotCreateOneItem() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonObject().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = null;
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonObject items = new JsonObject(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(0, items.size());
+  }
+}


### PR DESCRIPTION
## Purpose
The main purpose is to allow mapping for Multiple Items
## Approach
The mechanism for Multiple Holdings will create a new Item-entity for each marc field that defines holdings.permanentLocationId 
#### TODOS and Open Questions
- [ ] This PR should be merged with: https://github.com/folio-org/mod-inventory/pull/587
## Learning
Jira: https://issues.folio.org/browse/MODDICORE-90