### PR TITLE
MODDICORE-341: MARC Bib record doesn't open after update of repeatable linked field "$0" using mapping profile which allows to update

### DIFF
--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcBibRecordModifierTest.java
@@ -509,14 +509,14 @@ public class MarcBibRecordModifierTest extends MarcRecordModifierTest {
   public void shouldUnLinkWhenSubfield0ChangeInRepeatable() throws IOException {
       // given
       var existingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
-        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test3\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test0\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
       var incomingParsedContent = "{\"leader\":\"00049nam  22000371a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
-        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan Swift\"},{\"0\":\"test3\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
-      var expectedParsedContent = "{\"leader\":\"00124nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
-        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan Swift\"},{\"0\":\"test3\"},{\"9\":\"ddbf59b7-913b-42ac-b1c6-e50ae7b00e6a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test0 updated\"}, {\"9\":\"ddbf59b7-913b-42ac-b1c6-11111111a\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+      var expectedParsedContent = "{\"leader\":\"00088nam  22000491a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}," +
+        "{\"700\":{\"subfields\":[{\"a\":\"Jonatan\"},{\"0\":\"test0 updated\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
 
       testMarcUpdating(existingParsedContent, incomingParsedContent, expectedParsedContent,
-        constructMappingDetails("700", "*"), emptyList(), emptyList(), 0);
+        constructMappingDetails("700", "0"), emptyList(), emptyList(), 0, "700");
     }
 
   //field protection settings tests


### PR DESCRIPTION
## Purpose
_MARC Bib record doesn't open after update of repeatable linked field "$0" using mapping profile which allows to update._

## Approach
_Added one test case for unlinking from subfield 0 when it updates for repeateble mapping_
_Solved by [MODDICORE-346](https://issues.folio.org/browse/MODDICORE-346)_

