### PR TITLE
Multiple mapping and matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 
 ## 2023-03-xo v4.0.5-SNAPSHOT
 * [MODDICORE-322](https://issues.folio.org/browse/MODDICORE-322) Multiple 050 fields or subfields all map to Holdings/Item Call Number if Holdings/Item Mapping is set to 050$a or 050$a " " 050$b
+* [MODDICORE-336](https://issues.folio.org/browse/MODDICORE-336) Change Mapper to allow mapping of multiple Holdings
 
 ## 2023-02-17 v4.0.0
 * [MODSOURMAN-873](https://issues.folio.org/browse/MODSOURMAN-873) Add MARC 720 field to default MARC Bib-Instance mapping and adjust relator term mapping. Expanded default mapper with alternative mapping logic

--- a/ramls/settings/authoritysourcefile.json
+++ b/ramls/settings/authoritysourcefile.json
@@ -13,6 +13,7 @@
     },
     "codes": {
       "type" : "array",
+      "description": "array of codes",
       "items": {
         "type": "string",
         "description": "identifying prefix, i.e. 'n', 'D', 'fst'"

--- a/ramls/settings/location.json
+++ b/ramls/settings/location.json
@@ -32,6 +32,7 @@
       "type": "string"
     },
     "institution": {
+      "description": "Object of institution",
       "type": "object",
       "folio:$ref": "locinst.json",
       "readonly": true,
@@ -46,6 +47,7 @@
       "type": "string"
     },
     "campus": {
+      "description": "Object of campus",
       "type": "object",
       "folio:$ref": "loccamp.json",
       "readonly": true,
@@ -60,6 +62,7 @@
       "type": "string"
     },
     "library": {
+      "description": "Object of library",
       "type": "object",
       "folio:$ref": "locinst.json",
       "readonly": true,

--- a/src/main/java/org/folio/processing/mapping/mapper/FactoryRegistry.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/FactoryRegistry.java
@@ -1,5 +1,8 @@
 package org.folio.processing.mapping.mapper;
 
+import org.folio.DataImportEventPayload;
+import org.folio.processing.mapping.mapper.mappers.AbstractMapper;
+import org.folio.processing.mapping.mapper.mappers.MapperFactory;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.ReaderFactory;
 import org.folio.processing.mapping.mapper.writer.Writer;
@@ -18,6 +21,7 @@ import static java.lang.String.format;
 public class FactoryRegistry {
   private static final List<ReaderFactory> READER_FACTORIES = new ArrayList<>();
   private static final List<WriterFactory> WRITER_FACTORIES = new ArrayList<>();
+  private static final List<MapperFactory> MAPPER_FACTORIES = new ArrayList<>();
 
   /**
    * Creates reader by given entity type using reader factory
@@ -56,6 +60,25 @@ public class FactoryRegistry {
   }
 
   /**
+   * Created specific mapper by given
+   * @param dataImportEventPayload
+   * @param reader
+   * @param writer
+   * @return
+   */
+  public Mapper createMapper(DataImportEventPayload dataImportEventPayload, Reader reader, Writer writer) {
+    Optional<MapperFactory> optionalMapperFactory = MAPPER_FACTORIES.stream()
+      .filter(mapperFactory -> mapperFactory.isEligiblePayload(dataImportEventPayload))
+      .findFirst();
+    if (optionalMapperFactory.isPresent()) {
+      MapperFactory mapperFactory = optionalMapperFactory.get();
+      return mapperFactory.createMapper(reader, writer);
+    } else {
+      return new AbstractMapper(reader, writer);
+    }
+  }
+
+  /**
    * Returns list of registered reader factories
    *
    * @return list of reader factories
@@ -71,5 +94,14 @@ public class FactoryRegistry {
    */
   public List<WriterFactory> getWriterFactories() {
     return WRITER_FACTORIES;
+  }
+
+  /**
+   * Returns list of registered mapper factories
+   *
+   * @return list of mapper factories
+   */
+  public List<MapperFactory> getMapperFactories() {
+    return MAPPER_FACTORIES;
   }
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/FactoryRegistry.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/FactoryRegistry.java
@@ -7,6 +7,11 @@ import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.ReaderFactory;
 import org.folio.processing.mapping.mapper.writer.Writer;
 import org.folio.processing.mapping.mapper.writer.WriterFactory;
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.matcher.AbstractMatcher;
+import org.folio.processing.matching.matcher.Matcher;
+import org.folio.processing.matching.matcher.MatcherFactory;
+import org.folio.processing.matching.reader.MatchValueReader;
 import org.folio.rest.jaxrs.model.EntityType;
 
 import java.util.ArrayList;
@@ -21,6 +26,7 @@ import static java.lang.String.format;
 public class FactoryRegistry {
   private static final List<ReaderFactory> READER_FACTORIES = new ArrayList<>();
   private static final List<WriterFactory> WRITER_FACTORIES = new ArrayList<>();
+  private static final List<MatcherFactory> MATCHER_FACTORIES = new ArrayList<>();
   private static final List<MapperFactory> MAPPER_FACTORIES = new ArrayList<>();
 
   /**
@@ -60,6 +66,24 @@ public class FactoryRegistry {
   }
 
   /**
+   * Creates matcher by given entities type using matcher factory
+   *
+   * @param entityType type of the entity which MatcherFactory produces
+   * @return Reader
+   */
+  public Matcher createMatcher(EntityType entityType, MatchValueReader matchValueReader, MatchValueLoader matchValueLoader) {
+    Optional<MatcherFactory> optionalWriterFactory = MATCHER_FACTORIES.stream()
+      .filter(matcherFactory -> matcherFactory.isEligibleForEntityType(entityType))
+      .findFirst();
+    if (optionalWriterFactory.isPresent()) {
+      MatcherFactory matcherFactory = optionalWriterFactory.get();
+      return matcherFactory.createMatcher(matchValueReader, matchValueLoader);
+    } else {
+      return new AbstractMatcher(matchValueReader, matchValueLoader);
+    }
+  }
+
+  /**
    * Created specific mapper by given
    * @param dataImportEventPayload
    * @param reader
@@ -94,6 +118,15 @@ public class FactoryRegistry {
    */
   public List<WriterFactory> getWriterFactories() {
     return WRITER_FACTORIES;
+  }
+
+  /**
+   * Returns list of registered matcher factories
+   *
+   * @return list of matcher factories
+   */
+  public List<MatcherFactory> getMatcherFactories() {
+    return MATCHER_FACTORIES;
   }
 
   /**

--- a/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/Mapper.java
@@ -1,5 +1,8 @@
 package org.folio.processing.mapping.mapper;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.folio.DataImportEventPayload;
 import org.folio.MappingProfile;
 import org.folio.processing.mapping.mapper.reader.Reader;
@@ -8,6 +11,8 @@ import org.folio.processing.value.Value;
 import org.folio.rest.jaxrs.model.MappingRule;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -18,33 +23,92 @@ import java.util.List;
  * @see Value
  */
 public interface Mapper {
+  String MARC_BIBLIOGRAPHIC = "MARC_BIBLIOGRAPHIC";
+  String CONTENT = "content";
+  String FIELDS = "fields";
+  String PARSED_RECORD = "parsedRecord";
+  String EMPTY_JSON = "{}";
 
   /**
    * Template method for mapping.
    *
-   * @param reader         Reader to read values from given event payload
-   * @param writer         Writer to write values to given event payload
-   * @param eventPayload   event payload
-   * @param mappingContext mapping context
-   * @return event payload
+   * @param profile        - current Mapping Profile
+   * @param eventPayload   - current eventPayload
+   * @param mappingContext - current Context
+   * @return - DataImportEventPayload with mapped entities inside
+   */
+  DataImportEventPayload map(MappingProfile profile, DataImportEventPayload eventPayload, MappingContext mappingContext);
+
+  /**
+   * Initialization reader and writer
+   *
+   * @param reader         -     Reader to read values from given event payload
+   * @param writer         -    Writer to write values to given event payload
+   * @param eventPayload   - current eventPayload
+   * @param mappingContext - current Context
    * @throws IOException if a low-level I/O problem occurs (JSON serialization)
    */
-  default DataImportEventPayload map(Reader reader, Writer writer, MappingProfile profile, DataImportEventPayload eventPayload,
-                                     MappingContext mappingContext) throws IOException {
+  default void initializeReaderAndWriter(DataImportEventPayload eventPayload, Reader reader, Writer writer, MappingContext mappingContext) throws IOException {
     reader.initialize(eventPayload, mappingContext);
     writer.initialize(eventPayload);
-    if (profile.getMappingDetails() == null
-      || profile.getMappingDetails().getMappingFields() == null
-      || profile.getMappingDetails().getMappingFields().isEmpty()) {
-      return eventPayload;
+  }
+
+  /**
+   * Check if MappingProfile is valid
+   *
+   * @param profile - current Mapping Profile
+   * @return true if MappingProfile is valid otherwise - false.
+   */
+  default boolean ifProfileIsInvalid(MappingProfile profile) {
+    return profile.getMappingDetails() == null || profile.getMappingDetails().getMappingFields() == null || profile.getMappingDetails().getMappingFields().isEmpty();
+  }
+
+  default JsonArray mapMultipleEntitiesByMarcField(DataImportEventPayload eventPayload, MappingContext mappingContext, Reader reader, Writer writer,
+                                                   List<MappingRule> mappingRules, String entityType, String marcField) throws IOException {
+    HashMap<String, String> payloadContext = eventPayload.getContext();
+    JsonArray entities = new JsonArray();
+
+    JsonObject originalMarcBib = new JsonObject(payloadContext.get(MARC_BIBLIOGRAPHIC));
+    JsonObject content = new JsonObject(originalMarcBib.getJsonObject(PARSED_RECORD).getString(CONTENT));
+    List<JsonObject> multipleEntityFields = new ArrayList<>();
+    List<JsonObject> nonMultipleFields = new ArrayList<>();
+
+    content.getJsonArray(FIELDS).forEach(e -> {
+      JsonObject field = (JsonObject) e;
+      if (field.getValue(marcField) != null) multipleEntityFields.add(new JsonObject(field.toString()));
+      else nonMultipleFields.add(new JsonObject(field.toString()));
+    });
+
+    for (JsonObject field : multipleEntityFields) {
+      List<JsonObject> singleEntityFields = new ArrayList<>(nonMultipleFields);
+      singleEntityFields.add(field);
+      content.put(FIELDS, singleEntityFields);
+
+      JsonObject marcBibForSingleEntity = originalMarcBib.copy();
+      marcBibForSingleEntity.getJsonObject(PARSED_RECORD).put(CONTENT, content.encode());
+      payloadContext.put(entityType, EMPTY_JSON);
+      payloadContext.put(MARC_BIBLIOGRAPHIC, marcBibForSingleEntity.encode());
+
+      reader.initialize(eventPayload, mappingContext);
+      writer.initialize(eventPayload);
+      entities.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, entityType));
     }
-    List<MappingRule> mappingRules = profile.getMappingDetails().getMappingFields();
+
+    payloadContext.put(MARC_BIBLIOGRAPHIC, originalMarcBib.encode());
+    reader.initialize(eventPayload, mappingContext);
+    writer.initialize(eventPayload);
+    return entities;
+  }
+
+  default JsonObject mapSingleEntity(DataImportEventPayload eventPayload, Reader reader, Writer writer,
+                                     List<MappingRule> mappingRules, String entityType) throws JsonProcessingException {
     for (MappingRule rule : mappingRules) {
       if (Boolean.parseBoolean(rule.getEnabled())) {
         Value value = reader.read(rule);
         writer.write(rule.getPath(), value);
       }
     }
-    return writer.getResult(eventPayload);
+    DataImportEventPayload resultedPayload = writer.getResult(eventPayload);
+    return new JsonObject(resultedPayload.getContext().get(entityType));
   }
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/AbstractMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/AbstractMapper.java
@@ -1,0 +1,49 @@
+package org.folio.processing.mapping.mapper.mappers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.processing.exceptions.MappingException;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.MappingContext;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.processing.value.Value;
+import org.folio.rest.jaxrs.model.MappingRule;
+
+import java.io.IOException;
+import java.util.List;
+
+public class AbstractMapper implements Mapper {
+  private static final Logger LOGGER = LogManager.getLogger(AbstractMapper.class);
+
+  private Reader reader;
+  private Writer writer;
+
+  public AbstractMapper(Reader reader, Writer writer) {
+    this.reader = reader;
+    this.writer = writer;
+  }
+
+  @Override
+  public DataImportEventPayload map(MappingProfile profile, DataImportEventPayload eventPayload, MappingContext mappingContext) {
+    try {
+      initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+      if (ifProfileIsInvalid(profile)) {
+        return eventPayload;
+      }
+      List<MappingRule> mappingRules = profile.getMappingDetails().getMappingFields();
+      for (MappingRule rule : mappingRules) {
+        if (Boolean.parseBoolean(rule.getEnabled())) {
+          Value value = reader.read(rule);
+          writer.write(rule.getPath(), value);
+        }
+      }
+      return writer.getResult(eventPayload);
+    } catch (IOException e) {
+      LOGGER.warn("map:: Failed to perform Abstract mapping", e);
+      throw new MappingException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -13,6 +13,7 @@ import org.folio.processing.mapping.mapper.Mapper;
 import org.folio.processing.mapping.mapper.MappingContext;
 import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.MappingRule;
 
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class HoldingsMapper implements Mapper {
   private static final String PERMANENT_LOCATION_ID = "permanentLocationId";
   private static final String HOLDINGS = "HOLDINGS";
   private static final String HOLDINGS_IDENTIFIERS = "HOLDINGS_IDENTIFIERS";
-  private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
+  public static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
   private Reader reader;
   private Writer writer;
 
@@ -60,7 +61,7 @@ public class HoldingsMapper implements Mapper {
     Optional<MappingRule> permanentLocationMappingRule = mappingRules.stream().filter(rule -> rule.getName().equals(PERMANENT_LOCATION_ID)).findFirst();
 
     if (permanentLocationMappingRule.isEmpty() || !isStaredWithMarcField(permanentLocationMappingRule.get().getValue())) {
-      adjustContextToContainHoldingsAsJsonObject(eventPayload);
+      adjustContextToContainEntitiesAsJsonObject(eventPayload, EntityType.HOLDINGS);
       writer.initialize(eventPayload);
       holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
     } else {
@@ -87,24 +88,6 @@ public class HoldingsMapper implements Mapper {
       reader.initialize(eventPayload, mappingContext);
       writer.initialize(eventPayload);
       holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
-    }
-  }
-
-  private void adjustContextToContainHoldingsAsJsonObject(DataImportEventPayload eventPayload) {
-    if (isJsonArray(eventPayload.getContext().get(HOLDINGS))) {
-      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS));
-      if (holdings.size() > 0) {
-        eventPayload.getContext().put(HOLDINGS, holdings.getJsonObject(0).encode());
-      }
-    }
-  }
-
-  private boolean isJsonArray(String jsonArrayAsString) {
-    try {
-      new JsonArray(jsonArrayAsString);
-      return true;
-    } catch (DecodeException e) {
-      return false;
     }
   }
 

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -1,6 +1,5 @@
 package org.folio.processing.mapping.mapper.mappers;
 
-import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -67,7 +66,7 @@ public class HoldingsMapper implements Mapper {
     } else {
       String expressionPart = permanentLocationMappingRule.get().getValue().split(WHITESPACE_DIVIDER)[0];
       String marcField = retrieveMarcFieldName(expressionPart)
-        .orElseThrow(() -> new RuntimeException(String.format("Invalid  value for mapping rule: %s", PERMANENT_LOCATION_ID)));
+        .orElseThrow(() -> new MappingException(String.format("Invalid  value for mapping rule: %s", PERMANENT_LOCATION_ID)));
       eventPayload.getContext().put(MULTIPLE_HOLDINGS_FIELD, marcField);
       if (new JsonArray(eventPayload.getContext().get(HOLDINGS)).isEmpty()) {
         holdings = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, HOLDINGS, marcField);

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -1,0 +1,148 @@
+package org.folio.processing.mapping.mapper.mappers;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.processing.exceptions.MappingException;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.MappingContext;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.MappingRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.folio.processing.mapping.mapper.reader.record.marc.MarcRecordReader.MARC_PATTERN;
+import static org.folio.processing.mapping.mapper.reader.record.marc.MarcRecordReader.WHITESPACE_DIVIDER;
+
+public class HoldingsMapper implements Mapper {
+  private static final Logger LOGGER = LogManager.getLogger(HoldingsMapper.class);
+  private static final String PERMANENT_LOCATION_ID = "permanentLocationId";
+  private static final String HOLDINGS = "HOLDINGS";
+  private static final String HOLDINGS_IDENTIFIERS = "HOLDINGS_IDENTIFIERS";
+  private static final String MULTIPLE_HOLDINGS_FIELD = "MULTIPLE_HOLDINGS_FIELD";
+  private Reader reader;
+  private Writer writer;
+
+  public HoldingsMapper(Reader reader, Writer writer) {
+    this.reader = reader;
+    this.writer = writer;
+  }
+
+  @Override
+  public DataImportEventPayload map(MappingProfile profile, DataImportEventPayload eventPayload, MappingContext mappingContext) {
+    try {
+      initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+      if (ifProfileIsInvalid(profile)) {
+        return eventPayload;
+      }
+      return executeMultipleHoldingsLogic(eventPayload, profile, mappingContext);
+    } catch (IOException e) {
+      LOGGER.warn("map:: Failed to perform Holdings mapping", e);
+      throw new MappingException(e);
+    }
+  }
+
+  private DataImportEventPayload executeMultipleHoldingsLogic(DataImportEventPayload eventPayload,
+                                                              MappingProfile profile, MappingContext mappingContext) throws IOException {
+    List<MappingRule> mappingRules = profile.getMappingDetails().getMappingFields();
+    JsonArray holdings = new JsonArray();
+    Optional<MappingRule> permanentLocationMappingRule = mappingRules.stream().filter(rule -> rule.getName().equals(PERMANENT_LOCATION_ID)).findFirst();
+
+    if (permanentLocationMappingRule.isEmpty() || !isStaredWithMarcField(permanentLocationMappingRule.get().getValue())) {
+      adjustContextToContainHoldingsAsJsonObject(eventPayload);
+      writer.initialize(eventPayload);
+      holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
+    } else {
+      String expressionPart = permanentLocationMappingRule.get().getValue().split(WHITESPACE_DIVIDER)[0];
+      String marcField = retrieveMarcFieldName(expressionPart)
+        .orElseThrow(() -> new RuntimeException(String.format("Invalid  value for mapping rule: %s", PERMANENT_LOCATION_ID)));
+      eventPayload.getContext().put(MULTIPLE_HOLDINGS_FIELD, marcField);
+      if (new JsonArray(eventPayload.getContext().get(HOLDINGS)).isEmpty()) {
+        holdings = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, HOLDINGS, marcField);
+      } else {
+        mapMultipleHoldingsIfHoldingsEntityExistsInContext(eventPayload, mappingContext, mappingRules, holdings);
+      }
+    }
+    eventPayload.getContext().put(HOLDINGS_IDENTIFIERS, Json.encode(getPermanentLocationsFromHoldings(holdings)));
+    eventPayload.getContext().put(HOLDINGS, Json.encode(distinctHoldingsByPermanentLocation(holdings)));
+    return eventPayload;
+  }
+
+  private void mapMultipleHoldingsIfHoldingsEntityExistsInContext(DataImportEventPayload eventPayload, MappingContext mappingContext, List<MappingRule> mappingRules, JsonArray holdings) throws IOException {
+    JsonArray holdingsList = new JsonArray(eventPayload.getContext().get(HOLDINGS));
+    for (int i=0; i < holdingsList.size(); i++) {
+      JsonObject currentHolding = holdingsList.getJsonObject(i);
+      eventPayload.getContext().put(HOLDINGS, currentHolding.encode());
+      reader.initialize(eventPayload, mappingContext);
+      writer.initialize(eventPayload);
+      holdings.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, HOLDINGS));
+    }
+  }
+
+  private void adjustContextToContainHoldingsAsJsonObject(DataImportEventPayload eventPayload) {
+    if (isJsonArray(eventPayload.getContext().get(HOLDINGS))) {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS));
+      if (holdings.size() > 0) {
+        eventPayload.getContext().put(HOLDINGS, holdings.getJsonObject(0).encode());
+      }
+    }
+  }
+
+  private boolean isJsonArray(String jsonArrayAsString) {
+    try {
+      new JsonArray(jsonArrayAsString);
+      return true;
+    } catch (DecodeException e) {
+      return false;
+    }
+  }
+
+  private List<JsonObject> distinctHoldingsByPermanentLocation(JsonArray holdings) {
+    List<JsonObject> distinctHoldings = new ArrayList<>();
+    for (int i = 0; i < holdings.size(); i++) {
+      JsonObject holdingsAsJson = getHoldingsAsJson(holdings.getJsonObject(i));
+      String holdingPermanentLocation = holdingsAsJson.getString(PERMANENT_LOCATION_ID);
+
+      if (distinctHoldings.stream().noneMatch(hol -> Objects.equals(getHoldingsAsJson(hol).getString(PERMANENT_LOCATION_ID), holdingPermanentLocation))) {
+        distinctHoldings.add(holdings.getJsonObject(i));
+      }
+    }
+    return distinctHoldings;
+  }
+
+  private List<String> getPermanentLocationsFromHoldings(JsonArray holdings) {
+    List<String> permanentLocationsIds = new ArrayList<>();
+    holdings.forEach(e -> {
+      JsonObject holdingsAsJson = getHoldingsAsJson((JsonObject) e);
+      permanentLocationsIds.add(holdingsAsJson.getString(PERMANENT_LOCATION_ID));
+    });
+    return permanentLocationsIds;
+  }
+
+  private JsonObject getHoldingsAsJson(JsonObject holdings) {
+    if (holdings.getJsonObject("holdings") != null) {
+      return holdings.getJsonObject("holdings");
+    }
+    return holdings;
+  }
+
+  private boolean isStaredWithMarcField(String value) {
+    String[] expressionsParts = value.split(WHITESPACE_DIVIDER);
+    return expressionsParts.length > 0 && MARC_PATTERN.matcher(expressionsParts[0]).matches();
+  }
+
+  private Optional<String> retrieveMarcFieldName(String value) {
+    return Arrays.stream(value.split("\\$")).findFirst();
+  }
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/ItemMapper.java
@@ -1,0 +1,82 @@
+package org.folio.processing.mapping.mapper.mappers;
+
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.processing.exceptions.MappingException;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.MappingContext;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+import org.folio.rest.jaxrs.model.MappingRule;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.folio.processing.mapping.mapper.mappers.HoldingsMapper.MULTIPLE_HOLDINGS_FIELD;
+import static org.folio.rest.jaxrs.model.EntityType.ITEM;
+
+public class ItemMapper implements Mapper {
+  private static final Logger LOGGER = LogManager.getLogger(ItemMapper.class);
+  private final Reader reader;
+  private final Writer writer;
+
+  public ItemMapper(Reader reader, Writer writer) {
+    this.reader = reader;
+    this.writer = writer;
+  }
+
+  @Override
+  public DataImportEventPayload map(MappingProfile profile, DataImportEventPayload eventPayload, MappingContext mappingContext) {
+    try {
+      initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+      if (ifProfileIsInvalid(profile)) {
+        return eventPayload;
+      }
+      return executeMultipleItemsLogic(eventPayload, profile, mappingContext);
+    } catch (IOException e) {
+      LOGGER.warn("map:: Failed to perform Items mapping", e);
+      throw new MappingException(e);
+    }
+  }
+
+  private DataImportEventPayload executeMultipleItemsLogic(DataImportEventPayload eventPayload, MappingProfile profile,
+                                                           MappingContext mappingContext) throws IOException {
+    HashMap<String, String> payloadContext = eventPayload.getContext();
+    List<MappingRule> mappingRules = profile.getMappingDetails().getMappingFields();
+    JsonArray items = new JsonArray();
+    String marcField = payloadContext.get(MULTIPLE_HOLDINGS_FIELD);
+
+    if (marcField == null) {
+      adjustContextToContainEntitiesAsJsonObject(eventPayload, ITEM);
+      writer.initialize(eventPayload);
+      items.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, ITEM.value()));
+    } else {
+      if (new JsonArray(eventPayload.getContext().get(ITEM.value())).isEmpty()) {
+        items = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, ITEM.value(), marcField);
+        payloadContext.remove(MULTIPLE_HOLDINGS_FIELD);
+      } else {
+        mapMultipleItemIfItemEntityExistsInContext(eventPayload, mappingContext, payloadContext, mappingRules, items);
+      }
+    }
+    payloadContext.put(ITEM.value(), Json.encode(items));
+    return eventPayload;
+  }
+
+  private void mapMultipleItemIfItemEntityExistsInContext(DataImportEventPayload eventPayload, MappingContext mappingContext, HashMap<String, String> payloadContext, List<MappingRule> mappingRules, JsonArray items) throws IOException {
+    JsonArray itemList = new JsonArray(eventPayload.getContext().get(ITEM.value()));
+    for (int i=0; i < itemList.size(); i++) {
+      JsonObject currentItem = itemList.getJsonObject(i);
+      eventPayload.getContext().put(ITEM.value(), currentItem.encode());
+      reader.initialize(eventPayload, mappingContext);
+      writer.initialize(eventPayload);
+      items.add(mapSingleEntity(eventPayload, reader, writer, mappingRules, ITEM.value()));
+    }
+    payloadContext.remove(MULTIPLE_HOLDINGS_FIELD);
+  }
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/MapperFactory.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/MapperFactory.java
@@ -1,0 +1,27 @@
+package org.folio.processing.mapping.mapper.mappers;
+
+import org.folio.DataImportEventPayload;
+import org.folio.processing.mapping.mapper.Mapper;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.writer.Writer;
+
+/**
+ * Factory for creating specific mapper based on condition inside payload
+ */
+public interface MapperFactory {
+
+  /**
+   *  Create a new mapper for the specific type
+   * @param reader - reader
+   * @param writer - writer
+   * @return specific Mapper
+   */
+  Mapper createMapper(Reader reader, Writer writer);
+
+  /**
+   * Check if current mapper suits for current payload
+   * @param eventPayload - current DataImportEventPayload
+   * @return true if current mapper suits for this payload
+   */
+  boolean isEligiblePayload(DataImportEventPayload eventPayload);
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -60,11 +60,11 @@ import static org.folio.processing.value.Value.ValueType.MISSING;
 public class MarcRecordReader implements Reader {
   private static final Logger LOGGER = LogManager.getLogger(MarcRecordReader.class);
 
-  private final static Pattern MARC_PATTERN = Pattern.compile("(^[0-9]{3}(\\$[a-z0-9]$){0,2})");
+  public final static Pattern MARC_PATTERN = Pattern.compile("(^[0-9]{3}(\\$[a-z0-9]$){0,2})");
   private final static Pattern MARC_LEADER = Pattern.compile("^[LDR/]{4}[0-9-]{1,5}");
   private final static Pattern MARC_CONTROLLED = Pattern.compile("^[/0-9]{4}[0-9-]{1,5}");
-  private final static Pattern STRING_VALUE_PATTERN = Pattern.compile("(\"[^\"]+\")");
-  private final static String WHITESPACE_DIVIDER = "\\s(?=(?:[^'\"`]*(['\"`])[^'\"`]*\\1)*[^'\"`]*$)";
+  public final static Pattern STRING_VALUE_PATTERN = Pattern.compile("(\"[^\"]+\")");
+  public final static String WHITESPACE_DIVIDER = "\\s(?=(?:[^'\"`]*(['\"`])[^'\"`]*\\1)*[^'\"`]*$)";
   private final static String EXPRESSIONS_DIVIDER = "; else ";
   private final static String EXPRESSIONS_ARRAY = "[]";
   private final static String EXPRESSIONS_QUOTE = "\"";
@@ -163,7 +163,7 @@ public class MarcRecordReader implements Reader {
       resultList = resultList.stream().filter(r -> isNotBlank(r)).collect(Collectors.toList());
       List<String> tmpResultList = new ArrayList<>(resultList);
       String concatenator = sb.toString();
-      if(isNotBlank(concatenator)) {
+      if (isNotBlank(concatenator)) {
         for (int i = 0; i < tmpResultList.size(); i++) {
           String element = tmpResultList.get(i);
           resultList.set(i, element.concat(concatenator).toString());
@@ -255,6 +255,7 @@ public class MarcRecordReader implements Reader {
   private String retrieveNameWithoutCode(String mappingParameter) {
     return mappingParameter.substring(0, mappingParameter.trim().indexOf(FIRST_BRACKET) - 1);
   }
+
   /**
    * Process string expression method
    *
@@ -279,9 +280,11 @@ public class MarcRecordReader implements Reader {
     }
     return new StringBuilder(EMPTY);
   }
+
   /**
    * Process TODAY expression method
    * appends ZonedDateTime.now for tenant
+   *
    * @param sb                    uses for appending today value to buffer
    * @param multipleStringBuilder uses for appending today value to buffer
    * @throws IllegalArgumentException if can not format today

--- a/src/main/java/org/folio/processing/matching/MatchingManager.java
+++ b/src/main/java/org/folio/processing/matching/MatchingManager.java
@@ -7,9 +7,11 @@ import java.util.Map;
 import org.folio.DataImportEventPayload;
 import org.folio.MatchProfile;
 import org.folio.processing.exceptions.MatchingException;
+import org.folio.processing.mapping.mapper.FactoryRegistry;
 import org.folio.processing.matching.loader.MatchValueLoader;
 import org.folio.processing.matching.loader.MatchValueLoaderFactory;
 import org.folio.processing.matching.matcher.Matcher;
+import org.folio.processing.matching.matcher.MatcherFactory;
 import org.folio.processing.matching.reader.MatchValueReader;
 import org.folio.processing.matching.reader.MatchValueReaderFactory;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
@@ -25,6 +27,7 @@ import io.vertx.core.json.JsonObject;
  */
 public final class MatchingManager {
   private static final Logger LOGGER = LogManager.getLogger(MatchingManager.class);
+  private static final FactoryRegistry FACTORY_REGISTRY = new FactoryRegistry();
 
   private MatchingManager() {
   }
@@ -46,12 +49,21 @@ public final class MatchingManager {
       }
       MatchValueReader reader = MatchValueReaderFactory.build(matchProfile.getIncomingRecordType());
       MatchValueLoader loader = MatchValueLoaderFactory.build(matchProfile.getExistingRecordType());
-      future = new Matcher() {
-      }.match(reader, loader, eventPayload);
+      Matcher matcher = FACTORY_REGISTRY.createMatcher(matchProfile.getExistingRecordType(), reader, loader);
+
+      return matcher.match(eventPayload);
     } catch (Exception e) {
       LOGGER.warn("match:: Failed to perform matching", e);
       future.completeExceptionally(new MatchingException(e));
     }
     return future;
+  }
+
+  public static boolean registerMatcherFactory(MatcherFactory matcherFactory) {
+    return FACTORY_REGISTRY.getMatcherFactories().add(matcherFactory);
+  }
+
+  public static void clearMatcherFactories() {
+    FACTORY_REGISTRY.getMatcherFactories().clear();
   }
 }

--- a/src/main/java/org/folio/processing/matching/entities/PartialError.java
+++ b/src/main/java/org/folio/processing/matching/entities/PartialError.java
@@ -1,0 +1,27 @@
+package org.folio.processing.matching.entities;
+
+public class PartialError {
+  private String id;
+  private String error;
+
+  public PartialError(String id, String error) {
+    this.id = id;
+    this.error = error;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+}

--- a/src/main/java/org/folio/processing/matching/matcher/AbstractMatcher.java
+++ b/src/main/java/org/folio/processing/matching/matcher/AbstractMatcher.java
@@ -1,0 +1,82 @@
+package org.folio.processing.matching.matcher;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.DataImportEventPayload;
+import org.folio.MatchDetail;
+import org.folio.MatchProfile;
+import org.folio.processing.matching.loader.LoadResult;
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.loader.query.LoadQuery;
+import org.folio.processing.matching.loader.query.LoadQueryBuilder;
+import org.folio.processing.matching.reader.MatchValueReader;
+import org.folio.processing.matching.reader.util.MatchIdProcessorUtil;
+import org.folio.processing.value.StringValue;
+import org.folio.processing.value.Value;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.processing.matching.reader.util.MatchIdProcessorUtil.MAPPING_PARAMS_KEY;
+import static org.folio.processing.matching.reader.util.MatchIdProcessorUtil.RELATIONS_KEY;
+
+public class AbstractMatcher implements Matcher {
+  private final MatchValueReader matchValueReader;
+  private final MatchValueLoader matchValueLoader;
+  protected static final String NOT_MATCHED_NUMBER = "NOT_MATCHED_NUMBER";
+
+  public AbstractMatcher(MatchValueReader matchValueReader, MatchValueLoader matchValueLoader) {
+    this.matchValueReader = matchValueReader;
+    this.matchValueLoader = matchValueLoader;
+  }
+
+  @Override
+  public CompletableFuture<Boolean> match(DataImportEventPayload eventPayload) {
+    HashMap<String, String> payloadContext = eventPayload.getContext();
+    payloadContext.remove(NOT_MATCHED_NUMBER);
+    ProfileSnapshotWrapper matchingProfileWrapper = eventPayload.getCurrentNode();
+    MatchProfile matchProfile;
+    if (matchingProfileWrapper.getContent() instanceof Map) {
+      matchProfile = new JsonObject((Map) matchingProfileWrapper.getContent()).mapTo(MatchProfile.class);
+    } else {
+      matchProfile = (MatchProfile) matchingProfileWrapper.getContent();
+    }
+    // Only one matching detail is expected in first implementation,
+    // in future matching will support multiple matching details combined in logic expressions
+    MatchDetail matchDetail = matchProfile.getMatchDetails().get(0);
+
+    Value value = matchValueReader.read(eventPayload, matchDetail);
+    if (value != null && value.getType().equals(Value.ValueType.STRING)) {
+      value = MatchIdProcessorUtil.retrieveIdFromContext(matchDetail.getExistingMatchExpression().getFields().get(0).getValue(),
+        eventPayload, (StringValue) value);
+    }
+
+    payloadContext.remove(RELATIONS_KEY);
+    payloadContext.remove(MAPPING_PARAMS_KEY);
+    return performMatching(value, matchDetail, eventPayload);
+  }
+
+  protected CompletableFuture<Boolean> performMatching(Value value, MatchDetail matchDetail, DataImportEventPayload eventPayload) {
+    CompletableFuture<Boolean> future = new CompletableFuture<>();
+    loadEntity(value, matchDetail, eventPayload)
+      .whenComplete((loadResult, throwable) -> {
+        if (throwable != null) {
+          future.completeExceptionally(throwable);
+        } else {
+          if (loadResult.getValue() != null) {
+            eventPayload.getContext().put(loadResult.getEntityType(), loadResult.getValue());
+            future.complete(true);
+          } else {
+            future.complete(false);
+          }
+        }
+      });
+    return future;
+  }
+
+  protected CompletableFuture<LoadResult> loadEntity(Value value, MatchDetail matchDetail, DataImportEventPayload eventPayload) {
+    LoadQuery query = LoadQueryBuilder.build(value, matchDetail);
+    return matchValueLoader.loadEntity(query, eventPayload);
+  }
+}

--- a/src/main/java/org/folio/processing/matching/matcher/HoldingsItemMatcher.java
+++ b/src/main/java/org/folio/processing/matching/matcher/HoldingsItemMatcher.java
@@ -1,0 +1,84 @@
+package org.folio.processing.matching.matcher;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.DataImportEventPayload;
+import org.folio.MatchDetail;
+import org.folio.processing.exceptions.MatchingException;
+import org.folio.processing.matching.entities.PartialError;
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.reader.MatchValueReader;
+import org.folio.processing.value.ListValue;
+import org.folio.processing.value.StringValue;
+import org.folio.processing.value.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class HoldingsItemMatcher extends AbstractMatcher {
+  private static final String ERRORS = "ERRORS";
+  private static final String EMPTY_JSON_ARRAY = "[]";
+
+  public HoldingsItemMatcher(MatchValueReader matchValueReader, MatchValueLoader matchValueLoader) {
+    super(matchValueReader, matchValueLoader);
+  }
+
+  @Override
+  public CompletableFuture<Boolean> performMatching(Value value, MatchDetail matchDetail, DataImportEventPayload eventPayload) {
+    if (value instanceof ListValue) {
+      return processMultipleMatching(value, matchDetail, eventPayload);
+    }
+    return super.performMatching(value, matchDetail, eventPayload)
+      .whenComplete((matched, throwable) -> {
+        if (throwable == null) {
+          String entityType = matchDetail.getExistingRecordType().value();
+          String entityAsJsonString = eventPayload.getContext().get(entityType);
+          String jsonArrayOfEntitiesAsString = entityAsJsonString != null ? new JsonArray().add(new JsonObject(entityAsJsonString)).encode() : EMPTY_JSON_ARRAY;
+          eventPayload.getContext().put(entityType, jsonArrayOfEntitiesAsString);
+        }
+      });
+  }
+
+  private CompletableFuture<Boolean> processMultipleMatching(Value genericValue, MatchDetail matchDetail,
+                                                             DataImportEventPayload eventPayload) {
+    CompletableFuture<Boolean> resultFuture = new CompletableFuture<>();
+    List<Value> values = ((ListValue) genericValue).getValue().stream().distinct().map(StringValue::of).collect(Collectors.toList());
+    JsonArray matchedEntities = new JsonArray();
+    JsonArray errors = new JsonArray();
+
+    List<Future> multipleFutures = new ArrayList<>();
+    values.forEach(v -> {
+      Promise<Void> promise = Promise.promise();
+      multipleFutures.add(promise.future());
+      loadEntity(v, matchDetail, eventPayload)
+        .whenComplete((loadResult, throwable) -> {
+          if (throwable != null) {
+            errors.add(new PartialError(null, throwable.getMessage()));
+          } else {
+            if (loadResult.getValue() != null) matchedEntities.add(new JsonObject(loadResult.getValue()));
+          }
+          promise.complete();
+        });
+    });
+
+    CompositeFuture.join(multipleFutures)
+      .onComplete(ar -> {
+        String errorsAsStringJson = errors.encode();
+        if (matchedEntities.size() == 0 && errors.size() == values.size()) {
+          resultFuture.completeExceptionally(new MatchingException(errorsAsStringJson));
+        } else {
+          eventPayload.getContext().put(ERRORS, errorsAsStringJson);
+          eventPayload.getContext().put(matchDetail.getExistingRecordType().value(), matchedEntities.encode());
+          eventPayload.getContext().put(NOT_MATCHED_NUMBER, String.valueOf(values.size() - matchedEntities.size() - errors.size()));
+          resultFuture.complete(matchedEntities.size() > 0);
+        }
+      });
+
+    return resultFuture;
+  }
+}

--- a/src/main/java/org/folio/processing/matching/matcher/Matcher.java
+++ b/src/main/java/org/folio/processing/matching/matcher/Matcher.java
@@ -1,62 +1,8 @@
 package org.folio.processing.matching.matcher;
 
-import io.vertx.core.json.JsonObject;
-
 import org.folio.DataImportEventPayload;
-import org.folio.MatchDetail;
-import org.folio.MatchProfile;
-import org.folio.processing.matching.loader.MatchValueLoader;
-import org.folio.processing.matching.loader.query.LoadQuery;
-import org.folio.processing.matching.loader.query.LoadQueryBuilder;
-import org.folio.processing.matching.reader.MatchValueReader;
-import org.folio.processing.matching.reader.util.MatchIdProcessorUtil;
-import org.folio.processing.value.StringValue;
-import org.folio.processing.value.Value;
-import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
-
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import static org.folio.processing.matching.reader.util.MatchIdProcessorUtil.MAPPING_PARAMS_KEY;
-import static org.folio.processing.matching.reader.util.MatchIdProcessorUtil.RELATIONS_KEY;
-
 public interface Matcher {
-
-  default CompletableFuture<Boolean> match(MatchValueReader matchValueReader, MatchValueLoader matchValueLoader, DataImportEventPayload eventPayload) {
-    CompletableFuture<Boolean> future = new CompletableFuture<>();
-    ProfileSnapshotWrapper matchingProfileWrapper = eventPayload.getCurrentNode();
-    MatchProfile matchProfile;
-    if (matchingProfileWrapper.getContent() instanceof Map) {
-      matchProfile = new JsonObject((Map) matchingProfileWrapper.getContent()).mapTo(MatchProfile.class);
-    } else {
-      matchProfile = (MatchProfile) matchingProfileWrapper.getContent();
-    }
-    // Only one matching detail is expected in first implementation,
-    // in future matching will support multiple matching details combined in logic expressions
-    MatchDetail matchDetail = matchProfile.getMatchDetails().get(0);
-
-    Value value = matchValueReader.read(eventPayload, matchDetail);
-    if (value != null && value.getType().equals(Value.ValueType.STRING)) {
-      value = MatchIdProcessorUtil.retrieveIdFromContext(matchDetail.getExistingMatchExpression().getFields().get(0).getValue(),
-        eventPayload, (StringValue) value);
-    }
-
-    eventPayload.getContext().remove(RELATIONS_KEY);
-    eventPayload.getContext().remove(MAPPING_PARAMS_KEY);
-    LoadQuery query = LoadQueryBuilder.build(value, matchDetail);
-    matchValueLoader.loadEntity(query, eventPayload)
-      .whenComplete((loadResult, throwable) -> {
-        if (throwable != null) {
-          future.completeExceptionally(throwable);
-        } else {
-          if (loadResult.getValue() != null) {
-            eventPayload.getContext().put(loadResult.getEntityType(), loadResult.getValue());
-            future.complete(true);
-          } else {
-            future.complete(false);
-          }
-        }
-      });
-    return future;
-  }
+  CompletableFuture<Boolean> match(DataImportEventPayload eventPayload);
 }

--- a/src/main/java/org/folio/processing/matching/matcher/MatcherFactory.java
+++ b/src/main/java/org/folio/processing/matching/matcher/MatcherFactory.java
@@ -1,0 +1,11 @@
+package org.folio.processing.matching.matcher;
+
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.reader.MatchValueReader;
+import org.folio.rest.jaxrs.model.EntityType;
+
+public interface MatcherFactory {
+  Matcher createMatcher(MatchValueReader matchValueReader, MatchValueLoader matchValueLoader);
+
+  boolean isEligibleForEntityType(EntityType entityType);
+}

--- a/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
@@ -56,6 +56,7 @@ public class MappingManagerUnitTest {
   public void beforeTest() {
     MappingManager.clearReaderFactories();
     MappingManager.clearWriterFactories();
+    MappingManager.clearMapperFactories();
   }
 
   @Test

--- a/src/test/java/org/folio/processing/mapping/mapper/HoldingsMapperTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/HoldingsMapperTest.java
@@ -1,0 +1,677 @@
+package org.folio.processing.mapping.mapper;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.DataImportEventPayload;
+import org.folio.Location;
+import org.folio.MappingProfile;
+import org.folio.ParsedRecord;
+import org.folio.Record;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.folio.processing.mapping.mapper.mappers.HoldingsMapper;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
+import org.folio.processing.mapping.mapper.writer.common.JsonBasedWriter;
+import org.folio.rest.jaxrs.model.EntityType;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MappingRule;
+import org.folio.rest.jaxrs.model.RepeatableSubfieldMapping;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(JUnit4.class)
+public class HoldingsMapperTest {
+  @Test
+  public void shouldCreateOneHoldingIfOnlySingleMARCfieldContainsLocation() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("permanentLocationId")
+          .withEnabled("true")
+          .withPath("holdings.permanentLocationId")
+          .withValue("945$h")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("holdings.statisticalCodeIds[]")
+          .withValue("\"Testing\"")));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size());
+    JsonObject firstHolding = holdings.getJsonObject(0);
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHolding.getJsonObject("holdings").getString("permanentLocationId"));
+    assertEquals("Testing", firstHolding.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(1, holdingsIdentifier.size());
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(0));
+  }
+
+  @Test
+  public void shouldCreateOneHoldingIfPermanentLocationIsStringValue() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonObject().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("permanentLocationId")
+          .withEnabled("true")
+          .withPath("holdings.permanentLocationId")
+          .withValue("\"KU/CC/DI/A\"; else 945$h")
+          .withAcceptedValues(acceptedValues)));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size());
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(1, holdingsIdentifier.size());
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", holdingsIdentifier.getString(0));
+  }
+
+  @Test
+  public void shouldMapOneHoldingInExistingHoldingIfPermanentLocationIsStringValue() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+
+    JsonArray holdingsAsJson = new JsonArray(List.of(
+      new JsonObject()
+        .put("id", UUID.randomUUID())
+        .put("permanentLocationId", UUID.randomUUID())));
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), holdingsAsJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+        .withName("permanentLocationId")
+        .withEnabled("true")
+        .withPath("holdings.permanentLocationId")
+        .withValue("\"KU/CC/DI/A\"; else 945$h")
+        .withAcceptedValues(acceptedValues)));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size());
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(1, holdingsIdentifier.size());
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", holdingsIdentifier.getString(0));
+  }
+
+  @Test
+  public void shouldCreateMultipleHoldingsButWithoutDuplicatedLocations() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"E\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"KU/CC/DI/A\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("permanentLocationId")
+          .withEnabled("true")
+          .withPath("holdings.permanentLocationId")
+          .withValue("945$h")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("temporaryLocationId")
+          .withEnabled("true")
+          .withPath("holdings.temporaryLocationId")
+          .withValue("945$a")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("holdings.statisticalCodeIds[]")
+          .withValue("")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+          .withSubfields(List.of(
+            new RepeatableSubfieldMapping()
+              .withOrder(0)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("\"Testing\""))),
+            new RepeatableSubfieldMapping()
+              .withOrder(1)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("945$s")))))));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(2, holdings.size());
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    JsonObject secondHoldings = holdings.getJsonObject(1);
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    assertEquals("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", firstHoldings.getJsonObject("holdings").getString("temporaryLocationId"));
+    assertEquals(2, firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").size());
+    assertEquals("Testing", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", secondHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    assertNull(secondHoldings.getJsonObject("holdings").getString("temporaryLocationId"));
+    assertEquals("Testing", secondHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals(1, secondHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").size());
+
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(3, holdingsIdentifier.size());
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(0));
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(1));
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", holdingsIdentifier.getString(2));
+  }
+
+  @Test
+  public void shouldCreateMultipleHoldingsUsingMappingRuleWithElseStatement() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"944\":{\"subfields\":[{\"s\":\"testCode2\"}],\"ind1\":\" \",\"ind2\":\" \"}}, {\"945\":{\"subfields\":[{\"a\":\"E\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"KU/CC/DI/A\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("permanentLocationId")
+          .withEnabled("true")
+          .withPath("holdings.permanentLocationId")
+          .withValue("945$h")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("temporaryLocationId")
+          .withEnabled("true")
+          .withPath("holdings.temporaryLocationId")
+          .withValue("945$a")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("holdings.statisticalCodeIds[]")
+          .withValue("")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+          .withSubfields(List.of(
+            new RepeatableSubfieldMapping()
+              .withOrder(0)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("\"Testing\""))),
+            new RepeatableSubfieldMapping()
+              .withOrder(1)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("945$s; else 944$s")))))));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(2, holdings.size());
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    JsonObject secondHoldings = holdings.getJsonObject(1);
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    assertEquals("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", firstHoldings.getJsonObject("holdings").getString("temporaryLocationId"));
+    assertEquals(2, firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").size());
+    assertEquals("Testing", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", secondHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    assertNull(secondHoldings.getJsonObject("holdings").getString("temporaryLocationId"));
+    assertEquals(2, secondHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").size());
+    assertEquals("Testing", secondHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode2", secondHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(1));
+
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(3, holdingsIdentifier.size());
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(0));
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(1));
+    assertEquals("53cf956f-c1df-410b-8bea-27f712cca7c0", holdingsIdentifier.getString(2));
+  }
+
+  @Test
+  public void shouldCreateSingleHoldingIfLocationsAreTheSame() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"AM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"asdf\"},{\"h\":\"fcd64ce1-6995-48f0-840e-89ffa2288371\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+        .withName("permanentLocationId")
+        .withEnabled("true")
+        .withPath("holdings.permanentLocationId")
+        .withValue("945$h")
+        .withAcceptedValues(acceptedValues)));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size());
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(3, holdingsIdentifier.size());
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(0));
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(1));
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(2));
+  }
+
+  @Test
+  public void shouldNotCreateOneHoldingsIfProfileIsInvalid() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"OM\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), new JsonObject().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = null;
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonObject holdings = new JsonObject(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(0, holdings.size());
+    assertNull(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+  }
+
+
+  @Test
+  public void shouldUpdateSingleHoldingsButWithoutDuplicatedLocations() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    String parsedContent = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"E\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(parsedContent));
+    JsonObject firstExistedHolding = new JsonObject();
+    String firstHoldingsId = String.valueOf(UUID.randomUUID());
+    String firstHoldingsHrid = String.valueOf(UUID.randomUUID());
+    String firstHoldingsInstanceId = String.valueOf(UUID.randomUUID());
+    String firstHoldingsPermanentLocationId = String.valueOf(UUID.randomUUID());
+    JsonObject firstExistedHoldingBody = new JsonObject();
+    firstExistedHoldingBody.put("id", firstHoldingsId);
+    firstExistedHoldingBody.put("hrid", firstHoldingsHrid);
+    firstExistedHoldingBody.put("instanceId", firstHoldingsInstanceId);
+    firstExistedHoldingBody.put("permanentLocationId", firstHoldingsPermanentLocationId);
+    firstExistedHolding.put("holdings",firstExistedHoldingBody);
+
+    JsonObject secondExistedHolding = new JsonObject();
+    String secondHoldingsId = String.valueOf(UUID.randomUUID());
+    String secondHoldingsHrid = String.valueOf(UUID.randomUUID());
+    String secondHoldingsInstanceId = String.valueOf(UUID.randomUUID());
+    String secondHoldingsPermanentLocationId = String.valueOf(UUID.randomUUID());
+    JsonObject secondExistedHoldingBody = new JsonObject();
+    secondExistedHoldingBody.put("id", secondHoldingsId);
+    secondExistedHoldingBody.put("hrid", secondHoldingsHrid);
+    secondExistedHoldingBody.put("instanceId", secondHoldingsInstanceId);
+    secondExistedHoldingBody.put("permanentLocationId", secondHoldingsPermanentLocationId);
+    secondExistedHolding.put("holdings",secondExistedHoldingBody);
+
+    JsonArray existedHoldings = new JsonArray();
+    existedHoldings
+      .add(firstExistedHolding);
+    existedHoldings
+      .add(secondExistedHolding);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(HOLDINGS.value(), existedHoldings.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Main Library (KU/CC/DI/M)");
+    acceptedValues.put("53cf956f-c1df-410b-8bea-27f712cca7c0", "Annex (KU/CC/DI/A)");
+    acceptedValues.put("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", "Online (E)");
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("holdings")
+      .withRecordType(HOLDINGS)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("permanentLocationId")
+          .withEnabled("true")
+          .withPath("holdings.permanentLocationId")
+          .withValue("945$h")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("temporaryLocationId")
+          .withEnabled("true")
+          .withPath("holdings.temporaryLocationId")
+          .withValue("945$a")
+          .withAcceptedValues(acceptedValues),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("holdings.statisticalCodeIds[]")
+          .withValue("")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+          .withSubfields(List.of(
+            new RepeatableSubfieldMapping()
+              .withOrder(0)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("\"Testing\""))),
+            new RepeatableSubfieldMapping()
+              .withOrder(1)
+              .withPath("holdings.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("holdings.statisticalCodeIds[]")
+                .withValue("945$s")))))));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Update testing Holdings")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(HOLDINGS)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext()
+      .withMappingParameters(new MappingParameters()
+        .withLocations(Lists.newArrayList(Lists.newArrayList(new Location()
+          .withId("fcd64ce1-6995-48f0-840e-89ffa2288371")
+          .withName("Main Library")
+          .withCode("KU/CC/DI/M")))));
+
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(EntityType.HOLDINGS);
+    Mapper mapper = new HoldingsMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
+    JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
+    assertEquals(1, holdings.size()); // There will be just 1 Holdings because there is duplicated permanentLocationId in the second Holdings
+    JsonObject firstHoldings = holdings.getJsonObject(0);
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
+    assertEquals("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", firstHoldings.getJsonObject("holdings").getString("temporaryLocationId"));
+    assertEquals(2, firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").size());
+    assertEquals("Testing", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode", firstHoldings.getJsonObject("holdings").getJsonArray("statisticalCodeIds").getString(1));
+
+    JsonArray holdingsIdentifier = new JsonArray(mappedPayload.getContext().get("HOLDINGS_IDENTIFIERS"));
+    assertNotNull(holdingsIdentifier);
+    assertEquals(2, holdingsIdentifier.size());
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(0));
+    assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", holdingsIdentifier.getString(1));
+  }
+}

--- a/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/ItemMapperTest.java
@@ -1,0 +1,237 @@
+package org.folio.processing.mapping.mapper;
+
+import com.google.common.collect.Lists;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.DataImportEventPayload;
+import org.folio.MappingProfile;
+import org.folio.ParsedRecord;
+import org.folio.Record;
+import org.folio.processing.mapping.mapper.mappers.ItemMapper;
+import org.folio.processing.mapping.mapper.reader.Reader;
+import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
+import org.folio.processing.mapping.mapper.writer.common.JsonBasedWriter;
+import org.folio.rest.jaxrs.model.MappingDetail;
+import org.folio.rest.jaxrs.model.MappingRule;
+import org.folio.rest.jaxrs.model.RepeatableSubfieldMapping;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.folio.processing.mapping.mapper.mappers.HoldingsMapper.MULTIPLE_HOLDINGS_FIELD;
+import static org.folio.rest.jaxrs.model.EntityType.ITEM;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(JUnit4.class)
+public class ItemMapperTest {
+  private final String PARSED_CONTENT_WITH_MULTIPLE_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"944\":{\"subfields\":[{\"s\":\"testCode2\"}],\"ind1\":\" \",\"ind2\":\" \"}}, {\"945\":{\"subfields\":[{\"a\":\"E\"}, {\"b\":\"123\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"KU/CC/DI/A\"}, {\"b\":\"1234\"}, {\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+
+  @Test
+  public void shouldCreateOneItem() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("item")
+      .withRecordType(ITEM)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+          .withName("barcode")
+          .withEnabled("true")
+          .withPath("item.barcode")
+          .withValue("\"123\"")));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(1, items.size());
+    assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+  }
+
+  @Test
+  public void shouldMapExistingItemFromContext() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    UUID itemId = UUID.randomUUID();
+    JsonArray itemsAsJson = new JsonArray(List.of(
+      new JsonObject().put("item", new JsonObject().put("id", itemId))));
+
+    context.put(ITEM.value(), itemsAsJson.encode());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("item")
+      .withRecordType(ITEM)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+        .withName("barcode")
+        .withEnabled("true")
+        .withPath("item.barcode")
+        .withValue("\"123\"")));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(1, items.size());
+    assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+    assertEquals(itemId.toString(), items.getJsonObject(0).getJsonObject("item").getString("id"));
+  }
+
+  @Test
+  public void shouldCreateMultipleItemPerHoldingsPermanentLocationFields() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    context.put(MULTIPLE_HOLDINGS_FIELD, "945");
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = new MappingDetail()
+      .withName("item")
+      .withRecordType(ITEM)
+      .withMappingFields(Lists.newArrayList(new MappingRule()
+        .withName("barcode")
+        .withEnabled("true")
+        .withPath("item.barcode")
+        .withValue("945$b"),
+        new MappingRule()
+          .withName("statisticalCodeIds")
+          .withEnabled("true")
+          .withPath("item.statisticalCodeIds[]")
+          .withValue("")
+          .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+          .withSubfields(List.of(
+            new RepeatableSubfieldMapping()
+              .withOrder(0)
+              .withPath("item.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("item.statisticalCodeIds[]")
+                .withValue("\"Testing\""))),
+            new RepeatableSubfieldMapping()
+              .withOrder(1)
+              .withPath("item.statisticalCodeIds[]")
+              .withFields(List.of(new MappingRule()
+                .withName("statisticalCodeId")
+                .withEnabled("true")
+                .withPath("item.statisticalCodeIds[]")
+                .withValue("945$s; else 944$s")))))));
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(3, items.size());
+    assertEquals("123", items.getJsonObject(0).getJsonObject("item").getString("barcode"));
+    assertEquals("1234", items.getJsonObject(1).getJsonObject("item").getString("barcode"));
+    assertNull(items.getJsonObject(2).getJsonObject("item").getString("barcode"));
+
+    assertEquals("Testing", items.getJsonObject(0).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode", items.getJsonObject(0).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("Testing", items.getJsonObject(1).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode2", items.getJsonObject(1).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+
+    assertEquals("Testing", items.getJsonObject(2).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(0));
+    assertEquals("testCode2", items.getJsonObject(2).getJsonObject("item").getJsonArray("statisticalCodeIds").getString(1));
+  }
+
+  @Test
+  public void shouldNotCreateOneItem() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    Record record = new Record().withParsedRecord(new ParsedRecord()
+      .withContent(PARSED_CONTENT_WITH_MULTIPLE_FIELDS));
+    HashMap<String, String> context = new HashMap<>();
+    context.put(ITEM.value(), new JsonArray().toString());
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encodePrettily(record));
+    eventPayload.setContext(context);
+
+    MappingDetail mappingDetails = null;
+
+    MappingProfile profile = new MappingProfile()
+      .withId(UUID.randomUUID().toString())
+      .withName("Create testing Items")
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withExistingRecordType(ITEM)
+      .withMappingDetails(mappingDetails);
+
+    MappingContext mappingContext = new MappingContext();
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    JsonBasedWriter writer = new JsonBasedWriter(ITEM);
+    Mapper mapper = new ItemMapper(reader, writer);
+    mapper.initializeReaderAndWriter(eventPayload, reader, writer, mappingContext);
+    DataImportEventPayload mappedPayload = mapper.map(profile, eventPayload, mappingContext);
+    assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
+    assertNotNull(mappedPayload.getContext().get(ITEM.value()));
+    JsonArray items = new JsonArray(mappedPayload.getContext().get(ITEM.value()));
+    assertEquals(0, items.size());
+  }
+}

--- a/src/test/java/org/folio/processing/matching/manager/MatchingManagerTest.java
+++ b/src/test/java/org/folio/processing/matching/manager/MatchingManagerTest.java
@@ -7,8 +7,12 @@ import org.folio.MatchDetail;
 import org.folio.MatchProfile;
 import org.folio.processing.exceptions.MatchingException;
 import org.folio.processing.matching.MatchingManager;
+import org.folio.processing.matching.loader.LoadResult;
+import org.folio.processing.matching.loader.MatchValueLoader;
 import org.folio.processing.matching.loader.MatchValueLoaderFactory;
+import org.folio.processing.matching.loader.query.LoadQuery;
 import org.folio.processing.matching.reader.MatchValueReaderFactory;
+import org.folio.rest.jaxrs.model.EntityType;
 import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,18 +22,35 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
 import static org.folio.rest.jaxrs.model.EntityType.EDIFACT_INVOICE;
+import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
 
 @RunWith(VertxUnitRunner.class)
 public class MatchingManagerTest {
+  private MatchValueLoader instanceValueLoader;
 
   @Before
   public void beforeTest() {
     MatchValueReaderFactory.clearReaderFactory();
     MatchValueLoaderFactory.clearLoaderFactory();
+    instanceValueLoader = new MatchValueLoader() {
+      @Override
+      public CompletableFuture<LoadResult> loadEntity(LoadQuery loadQuery, DataImportEventPayload eventPayload) {
+        CompletableFuture<LoadResult> future = new CompletableFuture<>();
+        LoadResult result = new LoadResult();
+        result.setValue("Some value");
+        result.setEntityType("INSTANCE");
+        future.complete(result);
+        return future;
+      }
+
+      @Override
+      public boolean isEligibleForEntityType(EntityType existingRecordType) {
+        return existingRecordType == INSTANCE;
+      }
+    };
   }
 
   @Test

--- a/src/test/java/org/folio/processing/matching/matcher/HoldingsItemMatcherTest.java
+++ b/src/test/java/org/folio/processing/matching/matcher/HoldingsItemMatcherTest.java
@@ -1,0 +1,482 @@
+package org.folio.processing.matching.matcher;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.folio.DataImportEventPayload;
+import org.folio.MatchDetail;
+import org.folio.MatchProfile;
+import org.folio.processing.exceptions.MatchingException;
+import org.folio.processing.matching.loader.LoadResult;
+import org.folio.processing.matching.loader.MatchValueLoader;
+import org.folio.processing.matching.reader.MatchValueReader;
+import org.folio.processing.value.ListValue;
+import org.folio.processing.value.StringValue;
+import org.folio.rest.jaxrs.model.Field;
+import org.folio.rest.jaxrs.model.MatchExpression;
+import org.folio.rest.jaxrs.model.ProfileSnapshotWrapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
+import static org.folio.rest.jaxrs.model.EntityType.ITEM;
+import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
+import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(VertxUnitRunner.class)
+public class HoldingsItemMatcherTest {
+  private static final String parsedContentWithMultiple = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"945\":{\"subfields\":[{\"a\":\"E\"},{\"s\":\"testCode\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"a\":\"KU/CC/DI/A\"},{\"h\":\"KU/CC/DI/M\"}],\"ind1\":\" \",\"ind2\":\" \"}},{\"945\":{\"subfields\":[{\"h\":\"KU/CC/DI/A\"}],\"ind1\":\" \",\"ind2\":\" \"}}]}";
+  private HoldingsItemMatcher matcher;
+  private MatchValueLoader holdingsValueLoader;
+  private MatchValueReader valueReader;
+
+  @Before
+  public void beforeTest() {
+    holdingsValueLoader = Mockito.mock(MatchValueLoader.class);
+    valueReader = Mockito.mock(MatchValueReader.class);
+
+    Mockito.doAnswer(invocationOnMock -> {
+      LoadResult loadResult = new LoadResult();
+      loadResult.setValue("{\"permanentLocationId\": \"testId\"}");
+      loadResult.setEntityType(HOLDINGS.value());
+      return CompletableFuture.completedFuture(loadResult);
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    Mockito.doAnswer(invocationOnMock -> ListValue.of(List.of("test1", "test2", "test3"))).when(valueReader).read(any(), any());
+    Mockito.doAnswer(invocationOnMock -> true).when(valueReader).isEligibleForEntityType(any());
+    matcher = new HoldingsItemMatcher(valueReader, holdingsValueLoader);
+  }
+
+  @Test
+  public void shouldNotMatchSingleHoldings(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> StringValue.of("test1")).when(valueReader).read(any(), any());
+
+    Mockito.doAnswer(invocationOnMock -> {
+      LoadResult loadResult = new LoadResult();
+      loadResult.setValue(null);
+      loadResult.setEntityType(HOLDINGS.value());
+      return CompletableFuture.completedFuture(loadResult);
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS)
+        .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+        .withExistingMatchExpression(new MatchExpression().withFields(List.of(new Field().withValue("945"))))));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put("NOT_MATCHED_NUMBER", "3");
+    context.put("MAPPING_PARAMS", "{}");
+    context.put("MATCHING_PARAMETERS_RELATIONS", "{}");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(0, holdings.size());
+      testContext.assertNull(throwable);
+      testContext.assertFalse(matched);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldMatchSingleHoldings(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> StringValue.of("test1")).when(valueReader).read(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS)
+        .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+        .withExistingMatchExpression(new MatchExpression().withFields(List.of(new Field().withValue("945"))))));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put("NOT_MATCHED_NUMBER", "3");
+    context.put("MAPPING_PARAMS", "{}");
+    context.put("MATCHING_PARAMETERS_RELATIONS", "{}");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(1, holdings.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldMatchSingleItem(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> StringValue.of("test1")).when(valueReader).read(any(), any());
+
+    Mockito.doAnswer(invocationOnMock -> {
+      LoadResult loadResult = new LoadResult();
+      loadResult.setValue("{\"permanentLocationId\": \"testId\"}");
+      loadResult.setEntityType(ITEM.value());
+      return CompletableFuture.completedFuture(loadResult);
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(ITEM)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(ITEM)
+        .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+        .withExistingMatchExpression(new MatchExpression().withFields(List.of(new Field().withValue("945"))))));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put("NOT_MATCHED_NUMBER", "3");
+    context.put("MAPPING_PARAMS", "{}");
+    context.put("MATCHING_PARAMETERS_RELATIONS", "{}");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray items = new JsonArray(eventPayload.getContext().get(ITEM.value()));
+      testContext.assertEquals(1, items.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldMatchMultipleHoldings(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> ListValue.of(List.of("test1", "test2", "test3", "test3"))).when(valueReader).read(any(), any());
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put("NOT_MATCHED_NUMBER", "3");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(3, holdings.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      testContext.assertEquals("0", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldMatchMultipleItems(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> {
+      LoadResult loadResult = new LoadResult();
+      loadResult.setValue("{\"permanentLocationId\": \"testId\"}");
+      loadResult.setEntityType(ITEM.value());
+      return CompletableFuture.completedFuture(loadResult);
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(ITEM)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(ITEM).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put("NOT_MATCHED_NUMBER", "3");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray items = new JsonArray(eventPayload.getContext().get(ITEM.value()));
+      testContext.assertEquals(3, items.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      testContext.assertEquals("0", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldFailMatchWhenErrorsForEachHolding(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> {
+      CompletableFuture<LoadResult> future = new CompletableFuture<>();
+      future.completeExceptionally(new MatchingException("Error"));
+      return future;
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      testContext.assertNotNull(throwable);
+      testContext.assertNull(matched);
+      JsonArray errors = new JsonArray(throwable.getMessage());
+      testContext.assertEquals(3, errors.size());
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldNotMatchWhenNoHoldingsFound(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> {
+      LoadResult loadResult = new LoadResult();
+      loadResult.setValue(null);
+      loadResult.setEntityType(HOLDINGS.value());
+      return CompletableFuture.completedFuture(loadResult);
+    }).when(holdingsValueLoader).loadEntity(any(), any());
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      testContext.assertNull(throwable);
+      testContext.assertFalse(matched);
+      testContext.assertEquals("3", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldMatchAndReturnPartialErrorsForFailedHoldings(TestContext testContext) {
+    Async async = testContext.async();
+    CompletableFuture<LoadResult> errorFuture = new CompletableFuture<>();
+    errorFuture.completeExceptionally(new MatchingException("Error"));
+
+    LoadResult loadResult = new LoadResult();
+    loadResult.setValue("{\"permanentLocationId\": \"testId\"}");
+    loadResult.setEntityType(HOLDINGS.value());
+
+    CompletableFuture<LoadResult> completedFuture = new CompletableFuture<>();
+    completedFuture.complete(loadResult);
+
+    Mockito.when(holdingsValueLoader.loadEntity(any(), any()))
+      .thenReturn(errorFuture)
+      .thenReturn(completedFuture)
+      .thenReturn(completedFuture);
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(2, holdings.size());
+      JsonArray errors = new JsonArray(eventPayload.getContext().get("ERRORS"));
+      testContext.assertEquals(1, errors.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      testContext.assertEquals("0", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+
+  @Test
+  public void shouldNonMatchAndReturnPartialErrorsForFailedHoldings(TestContext testContext) {
+    Async async = testContext.async();
+    Mockito.doAnswer(invocationOnMock -> ListValue.of(List.of("test1", "test2", "test3", "test4"))).when(valueReader).read(any(), any());
+    CompletableFuture<LoadResult> errorFuture = new CompletableFuture<>();
+    errorFuture.completeExceptionally(new MatchingException("Error"));
+
+    LoadResult loadResultNonMatched = new LoadResult();
+    loadResultNonMatched.setEntityType(HOLDINGS.value());
+    loadResultNonMatched.setValue(null);
+
+    CompletableFuture<LoadResult> completedFutureNonMatched = new CompletableFuture<>();
+    completedFutureNonMatched.complete(loadResultNonMatched);
+
+    Mockito.when(holdingsValueLoader.loadEntity(any(), any()))
+      .thenReturn(errorFuture)
+      .thenReturn(errorFuture)
+      .thenReturn(completedFutureNonMatched)
+      .thenReturn(completedFutureNonMatched);
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+    context.put(HOLDINGS.value(), "[]");
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(0, holdings.size());
+      JsonArray errors = new JsonArray(eventPayload.getContext().get("ERRORS"));
+      testContext.assertEquals(2, errors.size());
+      testContext.assertNull(throwable);
+      testContext.assertFalse(matched);
+      testContext.assertEquals("2", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+
+
+  @Test
+  public void shouldMatchAndReturnPartialErrorsForFailedHoldingsAndSetNumberOfNonMatchedHoldingsInContext(TestContext testContext) {
+    Async async = testContext.async();
+    CompletableFuture<LoadResult> errorFuture = new CompletableFuture<>();
+    errorFuture.completeExceptionally(new MatchingException("Error"));
+
+    LoadResult loadResultMatched = new LoadResult();
+    loadResultMatched.setEntityType(HOLDINGS.value());
+    loadResultMatched.setValue("{\"permanentLocationId\": \"testId\"}");
+
+    LoadResult loadResultNonMatched = new LoadResult();
+    loadResultNonMatched.setEntityType(HOLDINGS.value());
+    loadResultNonMatched.setValue(null);
+
+    CompletableFuture<LoadResult> completedFutureMatched = new CompletableFuture<>();
+    completedFutureMatched.complete(loadResultMatched);
+
+    CompletableFuture<LoadResult> completedFutureNonMatched = new CompletableFuture<>();
+    completedFutureNonMatched.complete(loadResultNonMatched);
+
+    Mockito.when(holdingsValueLoader.loadEntity(any(), any()))
+      .thenReturn(errorFuture)
+      .thenReturn(completedFutureMatched)
+      .thenReturn(completedFutureNonMatched);
+
+    MatchProfile matchProfile = new MatchProfile()
+      .withExistingRecordType(HOLDINGS)
+      .withIncomingRecordType(MARC_BIBLIOGRAPHIC)
+      .withMatchDetails(Collections.singletonList(new MatchDetail().withExistingRecordType(HOLDINGS).withIncomingRecordType(MARC_BIBLIOGRAPHIC)));
+
+    ProfileSnapshotWrapper matchProfileWrapper = new ProfileSnapshotWrapper();
+    matchProfileWrapper.setContent(matchProfile);
+    matchProfileWrapper.setContentType(MATCH_PROFILE);
+
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), parsedContentWithMultiple);
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    eventPayload.setContext(context);
+    eventPayload.setCurrentNode(matchProfileWrapper);
+
+    CompletableFuture<Boolean> result = matcher.match(eventPayload);
+
+    result.whenComplete((matched, throwable) -> {
+      JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
+      testContext.assertEquals(1, holdings.size());
+      JsonArray errors = new JsonArray(eventPayload.getContext().get("ERRORS"));
+      testContext.assertEquals(1, errors.size());
+      testContext.assertNull(throwable);
+      testContext.assertTrue(matched);
+      testContext.assertEquals("1", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
+      async.complete();
+    });
+  }
+}


### PR DESCRIPTION
## Purpose
Implement multiple mapping and matching

## Approach
### MODDICORE-340
A new Factory was created for the new Multiple Entities in the scope of [MODDICORE-336](https://issues.folio.org/browse/MODDICORE-336). The mechanism for Multiple Holdings will create a new Holdings-entity for each UNIQUE location (multiple fields for holdings should be placed in the same field with permLocId) in the MARC file.
### MODDICORE-90
The mechanism for Multiple Holdings will create a new Item-entity for each marc field that defines holdings.permanentLocationId
### MODDICORE-317
Added support for multiple matching, setting up ERRORS and amount of non-matched holdings/items in context

