### PR TITLE
MODDICORE-356: Upgrade data-import-processing-core to Java 17

### DIFF
--- a/.github/workflows/build-dependants.yml
+++ b/.github/workflows/build-dependants.yml
@@ -16,6 +16,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - uses: actions/cache@v2
         with:
           path: |
@@ -37,6 +41,10 @@ jobs:
       fail-fast: false
     timeout-minutes: 5
     steps:
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - run: git clone --depth 1 --recurse-submodules https://github.com/folio-org/mod-inventory
       - uses: actions/cache@v2
         with:
@@ -57,6 +65,10 @@ jobs:
       fail-fast: false
     timeout-minutes: 20
     steps:
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - run: git clone --depth 1 --recurse-submodules https://github.com/folio-org/mod-source-record-manager
       - uses: actions/cache@v2
         with:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildMvn {
   mvnDeploy = 'yes'
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 ## 2023-XX-XX v4.1.0-SNAPSHOT
+* [MODDICORE-356](https://issues.folio.org/browse/KAFKAWRAP-356) Upgrade data-import-processing-core to Java 17
 * [MODDICORE-347](https://issues.folio.org/browse/MODDICORE-347) MARC bib - FOLIO instance mapping | Adjust contributor and relator term mapping WRT punctuation
 
 ## 2023-03-xo v4.0.5-SNAPSHOT

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.7.1</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
@@ -124,6 +124,16 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>31.1-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
+      <version>23.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js-scriptengine</artifactId>
+      <version>23.0.0</version>
     </dependency>
 
     <dependency>
@@ -327,7 +337,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <compilerArgument>-Xlint:unchecked</compilerArgument>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <junit.version>4.13.2</junit.version>
     <vertx.version>4.3.7</vertx.version>
     <wiremock.version>2.27.2</wiremock.version>
-    <raml-module-builder.version>35.0.4</raml-module-builder.version>
+    <raml-module-builder.version>35.0.6</raml-module-builder.version>
     <sonar.exclusions>org.folio.processing.mapping.defaultmapper.**</sonar.exclusions>
     <sonar.exclusions>**/OkapiConnectionParams.java</sonar.exclusions>
     <sonar.coverage.exclusions>**/parameters/MappingParameters.java</sonar.coverage.exclusions>

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/JSManager.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/JSManager.java
@@ -21,7 +21,8 @@ public class JSManager {
 
   private static final Logger LOGGER = LogManager.getLogger(JSManager.class);
 
-  private static final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+  private static final String GRAAL_JS_ENGINE = "graal.js";
+  private static final ScriptEngine engine = new ScriptEngineManager().getEngineByName(GRAAL_JS_ENGINE);
   private static final Map<Integer, CompiledScript> preCompiledJS = new HashMap<>();
 
   public static Object runJScript(String jscript, String data) throws ScriptException {

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -737,11 +737,7 @@ public class Processor<T> {
 
       if (isCustom) {
         try {
-
-          splitData = ((jdk.nashorn.api.scripting.ScriptObjectMirror) JSManager.runJScript(param, data))
-            .values()
-            .iterator();
-
+          splitData = ((Map<?, ?>) JSManager.runJScript(param, data)).values().iterator();
         } catch (Exception e) {
           LOGGER.warn("expandSubfields:: Expanding a field via subFieldSplit must return an array of results. ");
           throw e;

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -345,7 +345,7 @@ public class Processor<T> {
     }
     if (subFields.stream().noneMatch(sf -> (checkIfSubfieldShouldBeHandled(subFieldsSet, sf)))) {
       //skip further processing if there are no subfields to map
-      LOGGER.debug("handleFields:: no subfields to map from {} to {}", subFields.stream().map(Subfield::getCode).collect(Collectors.toList()), subFieldsSet);
+      LOGGER.debug("handleFields:: no subfields to map from {} to {}", subFields.stream().map(Subfield::getCode).toList(), subFieldsSet);
       return;
     }
 

--- a/src/test/resources/org/folio/processing/pom/pom-sample.xml
+++ b/src/test/resources/org/folio/processing/pom/pom-sample.xml
@@ -125,7 +125,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <release>11</release>
+          <release>17</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/src/test/resources/org/folio/processing/pom/pom-sample.xml
+++ b/src/test/resources/org/folio/processing/pom/pom-sample.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.0.0</raml-module-builder-version>
+    <raml-module-builder-version>30.0.6</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
## Purpose
_Magration to Java 17._

## Approach
_Implies migration from Nashorn to GraalVM JS engine_

#### TODOS and Open Questions
- [ ] After merging the PR following modules SRM, SRS, mode-inventory, data-import should be updated with **data-import-processing-core** new version.
