### PR TITLE
MODDICORE-356: Upgrade aspectj-maven-plugin to Java 17

### DIFF
--- a/src/test/resources/org/folio/processing/pom/pom-sample.xml
+++ b/src/test/resources/org/folio/processing/pom/pom-sample.xml
@@ -86,6 +86,7 @@
 
   <properties>
     <vertx.version>3.9.1</vertx.version>
+    <aspectj.version>1.9.19</aspectj.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
@@ -193,13 +194,13 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>dev.aspectj</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
+        <version>1.13.1</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
-          <complianceLevel>1.8</complianceLevel>
+          <release>17</release>
           <XaddSerialVersionUID>true</XaddSerialVersionUID>
           <showWeaveInfo>true</showWeaveInfo>
           <aspectLibraries>
@@ -220,12 +221,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.5</version>
+            <version>${aspectj.version}</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.5</version>
+            <version>${aspectj.version}</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
## Purpose
_Upgrade `aspectj-maven-plugin` to Java 17 wIthin the scope of the whole module migration._

## Approach
_`groupId` of `aspectj-maven-plugin` is migrated from `com.nickwongdev` to `dev.aspectj`._
