### PR TITLE
FAT-6493: Set not matched number for single holdings match

### DIFF
--- a/src/main/java/org/folio/processing/matching/matcher/AbstractMatcher.java
+++ b/src/main/java/org/folio/processing/matching/matcher/AbstractMatcher.java
@@ -68,6 +68,7 @@ public class AbstractMatcher implements Matcher {
             eventPayload.getContext().put(loadResult.getEntityType(), loadResult.getValue());
             future.complete(true);
           } else {
+            eventPayload.getContext().put(NOT_MATCHED_NUMBER, String.valueOf(1));
             future.complete(false);
           }
         }

--- a/src/test/java/org/folio/processing/matching/matcher/HoldingsItemMatcherTest.java
+++ b/src/test/java/org/folio/processing/matching/matcher/HoldingsItemMatcherTest.java
@@ -94,6 +94,7 @@ public class HoldingsItemMatcherTest {
     result.whenComplete((matched, throwable) -> {
       JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
       testContext.assertEquals(0, holdings.size());
+      testContext.assertEquals("1", eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
       testContext.assertNull(throwable);
       testContext.assertFalse(matched);
       async.complete();
@@ -131,6 +132,7 @@ public class HoldingsItemMatcherTest {
     result.whenComplete((matched, throwable) -> {
       JsonArray holdings = new JsonArray(eventPayload.getContext().get(HOLDINGS.value()));
       testContext.assertEquals(1, holdings.size());
+      testContext.assertNull(eventPayload.getContext().get("NOT_MATCHED_NUMBER"));
       testContext.assertNull(throwable);
       testContext.assertTrue(matched);
       async.complete();


### PR DESCRIPTION
## Purpose
Fix journal records processing when single holding is not matched. 
It should a fix for two Karate tests (_FAT-944 Match MARC-to-MARC and update Instances, fail to update Holdings and Items_; _FAT-945 Match MARC-to-MARC and update Instances, Holdings, fail to update Items_)

## Approach
Set not matched number for single holdings match to properly handle journal records on SRM

## Tested locally
![image](https://github.com/folio-org/data-import-processing-core/assets/138673581/0a411bfd-eb14-44b4-8a36-88e847c710ed)

![image](https://github.com/folio-org/data-import-processing-core/assets/138673581/80ab99bd-e040-419f-86a4-e46f44d49b3f)

