### PR TITLE
MODDATAIMP-926: Add consortium values into authority source

### DIFF
--- a/ramls/authority.json
+++ b/ramls/authority.json
@@ -15,7 +15,7 @@
     "source": {
       "type": "string",
       "description": "The metadata source of the underlying record to the authority record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in data-import)",
-      "enum": ["MARC", "FOLIO"],
+      "enum": ["MARC", "FOLIO", "CONSORTIUM-MARC", "CONSORTIUM-FOLIO"],
       "readonly": true
     },
     "personalName": {


### PR DESCRIPTION
## Purpose
To be able to parse and check source value on mod-inventory for determining whether MARC authority record is being updated on member tenant or not.

## Approach
Adding enum values.

## Follow-up PR
https://github.com/folio-org/mod-inventory/pull/628

## Learning
[MODDATAIMP-926](https://issues.folio.org/browse/MODDATAIMP-926)
