### PR TITLE
MODDICORE-366: Remove distinct by permanentLocationId for multiple Holdings during mapping if Holdings already contain at the context

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODDICORE-360](https://issues.folio.org/browse/MODDICORE-360) Migrate to folio-kafka-wrapper 3.0.0 version
 * [MODDICORE-356](https://issues.folio.org/browse/MODDICORE-356) Upgrade data-import-processing-core to Java 17
 * [MODDICORE-347](https://issues.folio.org/browse/MODDICORE-347) MARC bib - FOLIO instance mapping | Adjust contributor and relator term mapping WRT punctuation
+* [MODDICORE-366](https://issues.folio.org/browse/MODDICORE-366) Remove distinct by permanentLocationId for multiple Holdings during mapping if Holdings already contain at the context
 
 ## 2023-03-xo v4.0.5-SNAPSHOT
 * [MODDICORE-322](https://issues.folio.org/browse/MODDICORE-322) Multiple 050 fields or subfields all map to Holdings/Item Call Number if Holdings/Item Mapping is set to 050$a or 050$a " " 050$b

--- a/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/mappers/HoldingsMapper.java
@@ -61,6 +61,7 @@ public class HoldingsMapper implements Mapper {
 
     if (isJsonArray(eventPayload.getContext().get(HOLDINGS)) && !new JsonArray(eventPayload.getContext().get(HOLDINGS)).isEmpty()) {
       mapMultipleHoldingsIfHoldingsEntityExistsInContext(eventPayload, mappingContext, mappingRules, holdings);
+      eventPayload.getContext().put(HOLDINGS, Json.encode(holdings));
     } else {
       if (permanentLocationMappingRule.isEmpty() || !isStaredWithMarcField(permanentLocationMappingRule.get().getValue())) {
         adjustContextToContainEntitiesAsJsonObject(eventPayload, EntityType.HOLDINGS);
@@ -73,9 +74,9 @@ public class HoldingsMapper implements Mapper {
         eventPayload.getContext().put(MULTIPLE_HOLDINGS_FIELD, marcField);
         holdings = mapMultipleEntitiesByMarcField(eventPayload, mappingContext, reader, writer, mappingRules, HOLDINGS, marcField);
       }
+      eventPayload.getContext().put(HOLDINGS, Json.encode(distinctHoldingsByPermanentLocation(holdings)));
     }
     eventPayload.getContext().put(HOLDINGS_IDENTIFIERS, Json.encode(getPermanentLocationsFromHoldings(holdings)));
-    eventPayload.getContext().put(HOLDINGS, Json.encode(distinctHoldingsByPermanentLocation(holdings)));
     return eventPayload;
   }
 

--- a/src/test/java/org/folio/processing/mapping/mapper/HoldingsMapperTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/HoldingsMapperTest.java
@@ -711,7 +711,6 @@ public class HoldingsMapperTest {
     assertNotNull(mappedPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(mappedPayload.getContext().get(HOLDINGS.value()));
     JsonArray holdings = new JsonArray(mappedPayload.getContext().get(HOLDINGS.value()));
-    assertEquals(1, holdings.size()); // There will be just 1 Holdings because there is duplicated permanentLocationId in the second Holdings
     JsonObject firstHoldings = holdings.getJsonObject(0);
     assertEquals("fcd64ce1-6995-48f0-840e-89ffa2288371", firstHoldings.getJsonObject("holdings").getString("permanentLocationId"));
     assertEquals("184aae84-a5bf-4c6a-85ba-4a7c73026cd5", firstHoldings.getJsonObject("holdings").getString("temporaryLocationId"));


### PR DESCRIPTION
## Purpose
Remove distinct by permanentLocationId for multiple Holdings during mapping if Holdings already contain at the context
## Approach
- Reorder invocation of distinctHoldingsByPermanentLocation in HoldingsMapper class by calling it in case of absence of holdings in the context. 
- Add to context, holdings when holdings exist in context.
