### PR TITLE
[MODDICORE-373] Add 'isDonor' field to organization schema

### DIFF
--- a/ramls/settings/organization.json
+++ b/ramls/settings/organization.json
@@ -395,6 +395,12 @@
       "type": "boolean",
       "default": false
     },
+    "isDonor": {
+      "id": "isDonor",
+      "description": "Used to designate whether this organization is a donor",
+      "type": "boolean",
+      "default": false
+    },
     "sanCode": {
       "description": "The SAN code for this organization address",
       "type": "string"


### PR DESCRIPTION
## Purpose
The import of file is completed with errors for orders creation

## Approach
Add 'isDonor' field to organization schema