### PR TITLE
MODDICORE-382: Remove from the payload extra key after Multiple Optimistic Locking error reveals

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2023-XX-XX v4.2.0-SANPSHOT
+* [MODDICORE-382](https://issues.folio.org/browse/MODDICORE-382) Remove from the payload extra key after Multiple Optimistic Locking error reveals
+
 ## 2023-10-11 v4.1.0
 * [MODDICORE-360](https://issues.folio.org/browse/MODDICORE-360) Migrate to folio-kafka-wrapper 3.0.0 version
 * [MODDICORE-356](https://issues.folio.org/browse/MODDICORE-356) Upgrade data-import-processing-core to Java 17

--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -42,6 +42,7 @@ public final class EventManager {
 
   public static final String POST_PROCESSING_INDICATOR = "POST_PROCESSING";
   public static final String POST_PROCESSING_RESULT_EVENT_KEY = "POST_PROCESSING_RESULT_EVENT";
+  public static final String OL_ACCUMULATIVE_RESULTS = "OL_ACCUMULATIVE_RESULTS";
 
   private static final Logger LOGGER = LogManager.getLogger(EventManager.class);
 

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -36,9 +36,9 @@ public class EventProcessorImpl implements EventProcessor {
         long startTime = System.nanoTime();
         eventHandler.handle(eventPayload)
           .thenApply(dataImportEventPayload -> eventHandler.isPostProcessingNeeded() ? preparePayloadForPostProcessing(dataImportEventPayload, eventHandler) : dataImportEventPayload)
+          .thenApply(this::updatePayloadIfNeeded)
           .whenComplete((payload, throwable) -> {
             logEventProcessingTime(eventType, startTime, eventPayload);
-            updatePayloadIfNeeded(payload);
             if (throwable != null) {
               future.completeExceptionally(throwable);
             } else {
@@ -88,7 +88,8 @@ public class EventProcessorImpl implements EventProcessor {
     return eventsChain.get(eventsChain.size() - 1);
   }
 
-  private void updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
+  private DataImportEventPayload updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
     dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
+    return dataImportEventPayload;
   }
 }

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -36,9 +36,9 @@ public class EventProcessorImpl implements EventProcessor {
         long startTime = System.nanoTime();
         eventHandler.handle(eventPayload)
           .thenApply(dataImportEventPayload -> eventHandler.isPostProcessingNeeded() ? preparePayloadForPostProcessing(dataImportEventPayload, eventHandler) : dataImportEventPayload)
+          .thenApply(this::updatePayloadIfNeeded)
           .whenComplete((payload, throwable) -> {
             logEventProcessingTime(eventType, startTime, eventPayload);
-            updatePayloadIfNeeded(payload);
             if (throwable != null) {
               future.completeExceptionally(throwable);
             } else {
@@ -88,9 +88,10 @@ public class EventProcessorImpl implements EventProcessor {
     return eventsChain.get(eventsChain.size() - 1);
   }
 
-  private void updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
-    if (dataImportEventPayload.getContext() != null) {
+  private DataImportEventPayload updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
+    if (dataImportEventPayload != null && dataImportEventPayload.getContext() != null) {
       dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
     }
+    return dataImportEventPayload;
   }
 }

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -89,9 +89,7 @@ public class EventProcessorImpl implements EventProcessor {
   }
 
   private DataImportEventPayload updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
-    if (dataImportEventPayload != null && dataImportEventPayload.getContext() != null) {
-      dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
-    }
+    dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
     return dataImportEventPayload;
   }
 }

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -36,9 +36,9 @@ public class EventProcessorImpl implements EventProcessor {
         long startTime = System.nanoTime();
         eventHandler.handle(eventPayload)
           .thenApply(dataImportEventPayload -> eventHandler.isPostProcessingNeeded() ? preparePayloadForPostProcessing(dataImportEventPayload, eventHandler) : dataImportEventPayload)
-          .thenApply(this::updatePayloadIfNeeded)
           .whenComplete((payload, throwable) -> {
             logEventProcessingTime(eventType, startTime, eventPayload);
+            updatePayloadIfNeeded(payload);
             if (throwable != null) {
               future.completeExceptionally(throwable);
             } else {
@@ -88,8 +88,9 @@ public class EventProcessorImpl implements EventProcessor {
     return eventsChain.get(eventsChain.size() - 1);
   }
 
-  private DataImportEventPayload updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
-    dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
-    return dataImportEventPayload;
+  private void updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
+    if (dataImportEventPayload.getContext() != null) {
+      dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
+    }
   }
 }

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static java.lang.String.format;
 import static org.folio.DataImportEventTypes.DI_SRS_MARC_AUTHORITY_RECORD_CREATED;
+import static org.folio.processing.events.EventManager.OL_ACCUMULATIVE_RESULTS;
 import static org.folio.processing.events.EventManager.POST_PROCESSING_INDICATOR;
 import static org.folio.processing.events.EventManager.POST_PROCESSING_RESULT_EVENT_KEY;
 
@@ -37,6 +38,7 @@ public class EventProcessorImpl implements EventProcessor {
           .thenApply(dataImportEventPayload -> eventHandler.isPostProcessingNeeded() ? preparePayloadForPostProcessing(dataImportEventPayload, eventHandler) : dataImportEventPayload)
           .whenComplete((payload, throwable) -> {
             logEventProcessingTime(eventType, startTime, eventPayload);
+            updatePayloadIfNeeded(payload);
             if (throwable != null) {
               future.completeExceptionally(throwable);
             } else {
@@ -84,5 +86,9 @@ public class EventProcessorImpl implements EventProcessor {
   private String getLastEvent(DataImportEventPayload eventPayload) {
     final var eventsChain = eventPayload.getEventsChain();
     return eventsChain.get(eventsChain.size() - 1);
+  }
+
+  private void updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {
+    dataImportEventPayload.getContext().remove(OL_ACCUMULATIVE_RESULTS);
   }
 }


### PR DESCRIPTION
## Purpose
The main purpose is to clear DataImportEventPayload after Multiple Optimistic Locking errors are revealed.

## Approach
Removed "OL_ACCUMULATIVE_RESULTS" after invoking handle()-method.

## Learning
JIRA: https://issues.folio.org/browse/MODDICORE-382

This PR should be merged BEFORE https://github.com/folio-org/mod-inventory/pull/639 will be merged.