### PR TITLE
MODDICORE-368 - 'else' statement in Field Mapping Profile for Statistical Code is ignored

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
 ## 2023-XX-XX v4.2.0-SANPSHOT
 * [MODDICORE-382](https://issues.folio.org/browse/MODDICORE-382) Remove from the payload extra key after Multiple Optimistic Locking error reveals
 
+## 2023-XX-XX v4.1.3-SANPSHOT
+* [MODDICORE-368](https://issues.folio.org/browse/MODDICORE-368) 'else' statement in Field Mapping Profile for Statistical Code is ignored
+
 ## 2023-10-11 v4.1.0
 * [MODDICORE-360](https://issues.folio.org/browse/MODDICORE-360) Migrate to folio-kafka-wrapper 3.0.0 version
 * [MODDICORE-356](https://issues.folio.org/browse/MODDICORE-356) Upgrade data-import-processing-core to Java 17

--- a/pom.xml
+++ b/pom.xml
@@ -116,11 +116,6 @@
       <version>4.4</version>
     </dependency>
     <dependency>
-      <groupId>net.sourceforge.collections</groupId>
-      <artifactId>collections-generic</artifactId>
-      <version>4.01</version>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>32.0.0-jre</version>

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -50,6 +50,7 @@ public class EventProcessorImpl implements EventProcessor {
         future.completeExceptionally(new EventHandlerNotFoundException(format("No suitable handler found for %s event type", eventPayload.getEventType())));
       }
     } catch (Exception e) {
+      LOG.warn("process:: Failed to process event payload", e);
       future.completeExceptionally(e);
     }
     return future;

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/AcceptedValuesMatcher.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/AcceptedValuesMatcher.java
@@ -1,0 +1,7 @@
+package org.folio.processing.mapping.mapper.reader.matcher;
+
+public interface AcceptedValuesMatcher {
+
+  boolean matches(String acceptedValue, String valueToCompare);
+
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/AcceptedValuesMatcher.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/AcceptedValuesMatcher.java
@@ -1,7 +1,20 @@
 package org.folio.processing.mapping.mapper.reader.matcher;
 
+/**
+ * A comparison function, which determines whether the specified value
+ * matches to accepted value retrieved from a {@link org.folio.MappingProfile}
+ */
+@FunctionalInterface
 public interface AcceptedValuesMatcher {
 
+  /**
+   * Checks whether specified {@code valueToCompare} matches to the {@code acceptedValue}
+   * by criteria that depend on this method implementation.
+   *
+   * @param acceptedValue   - accepted value from the mapping profile
+   * @param valueToCompare  - value to compare to the accepted value
+   * @return true if the {@code valueToCompare} matches to the {@code acceptedValue}, otherwise false
+   */
   boolean matches(String acceptedValue, String valueToCompare);
 
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
@@ -7,8 +7,7 @@ public class StatisticalCodeAcceptedValuesMatcher implements AcceptedValuesMatch
   @Override
   public boolean matches(String acceptedValue, String valueToCompare) {
     return matchesByCode(acceptedValue, valueToCompare)
-      || matchesByName(acceptedValue, valueToCompare)
-      || matchesByNameExcludingCode(acceptedValue, valueToCompare);
+      || matchesByName(acceptedValue, valueToCompare);
   }
 
   private boolean matchesByCode(String acceptedValue, String valueToCompare) {
@@ -19,11 +18,6 @@ public class StatisticalCodeAcceptedValuesMatcher implements AcceptedValuesMatch
   private boolean matchesByName(String acceptedValue, String valueToCompare) {
     String statisticalCodeName = StringUtils.substringAfter(acceptedValue, " - ");
     return valueToCompare.equalsIgnoreCase(statisticalCodeName);
-  }
-
-  private boolean matchesByNameExcludingCode(String acceptedValue, String valueToCompare) {
-    String statisticalCodeNameWithoutCodePart = StringUtils.substringBetween(acceptedValue, " - ", " (");
-    return valueToCompare.equalsIgnoreCase(statisticalCodeNameWithoutCodePart);
   }
 
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
@@ -4,6 +4,9 @@ import org.apache.commons.lang3.StringUtils;
 
 public class StatisticalCodeAcceptedValuesMatcher implements AcceptedValuesMatcher {
 
+  private static final String CODE_SEPARATOR = ": ";
+  private static final String NAME_SEPARATOR = " - ";
+
   @Override
   public boolean matches(String acceptedValue, String valueToCompare) {
     return matchesByCode(acceptedValue, valueToCompare)
@@ -11,13 +14,13 @@ public class StatisticalCodeAcceptedValuesMatcher implements AcceptedValuesMatch
   }
 
   private boolean matchesByCode(String acceptedValue, String valueToCompare) {
-    String code = StringUtils.substringBetween(acceptedValue, ": ", " - ");
-    return valueToCompare.equalsIgnoreCase(code);
+    String code = StringUtils.substringBetween(acceptedValue, CODE_SEPARATOR, NAME_SEPARATOR);
+    return valueToCompare.equals(code);
   }
 
   private boolean matchesByName(String acceptedValue, String valueToCompare) {
-    String statisticalCodeName = StringUtils.substringAfter(acceptedValue, " - ");
-    return valueToCompare.equalsIgnoreCase(statisticalCodeName);
+    String statisticalCodeName = StringUtils.substringAfter(acceptedValue, NAME_SEPARATOR);
+    return valueToCompare.equals(statisticalCodeName);
   }
 
 }

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcher.java
@@ -1,0 +1,29 @@
+package org.folio.processing.mapping.mapper.reader.matcher;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class StatisticalCodeAcceptedValuesMatcher implements AcceptedValuesMatcher {
+
+  @Override
+  public boolean matches(String acceptedValue, String valueToCompare) {
+    return matchesByCode(acceptedValue, valueToCompare)
+      || matchesByName(acceptedValue, valueToCompare)
+      || matchesByNameExcludingCode(acceptedValue, valueToCompare);
+  }
+
+  private boolean matchesByCode(String acceptedValue, String valueToCompare) {
+    String code = StringUtils.substringBetween(acceptedValue, ": ", " - ");
+    return valueToCompare.equalsIgnoreCase(code);
+  }
+
+  private boolean matchesByName(String acceptedValue, String valueToCompare) {
+    String statisticalCodeName = StringUtils.substringAfter(acceptedValue, " - ");
+    return valueToCompare.equalsIgnoreCase(statisticalCodeName);
+  }
+
+  private boolean matchesByNameExcludingCode(String acceptedValue, String valueToCompare) {
+    String statisticalCodeNameWithoutCodePart = StringUtils.substringBetween(acceptedValue, " - ", " (");
+    return valueToCompare.equalsIgnoreCase(statisticalCodeNameWithoutCodePart);
+  }
+
+}

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -92,7 +92,9 @@ public class MarcRecordReader implements Reader {
 
   MarcRecordReader(EntityType entityType) {
     this.entityType = entityType;
-    this.acceptedValuesMatchers = Map.of(STATISTICAL_CODE_ID_FIELD, new StatisticalCodeAcceptedValuesMatcher());
+    this.acceptedValuesMatchers = new HashMap<>() {{
+      put(STATISTICAL_CODE_ID_FIELD, new StatisticalCodeAcceptedValuesMatcher());
+    }};
   }
 
   @Override

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -92,9 +92,7 @@ public class MarcRecordReader implements Reader {
 
   MarcRecordReader(EntityType entityType) {
     this.entityType = entityType;
-    this.acceptedValuesMatchers = new HashMap<>() {{
-      put(STATISTICAL_CODE_ID_FIELD, new StatisticalCodeAcceptedValuesMatcher());
-    }};
+    this.acceptedValuesMatchers = Map.of(STATISTICAL_CODE_ID_FIELD, new StatisticalCodeAcceptedValuesMatcher());
   }
 
   @Override

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/common/FieldPathIterator.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/common/FieldPathIterator.java
@@ -1,6 +1,5 @@
 package org.folio.processing.mapping.mapper.writer.common;
 
-import org.apache.commons.collections15.iterators.ObjectArrayIterator;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
@@ -20,7 +19,7 @@ class FieldPathIterator {
     } else {
       String[] stringItems = path.split(DELIMITER_REGEX);
       PathItem[] pathItems = Arrays.stream(stringItems).map(PathItem::new).toArray(PathItem[]::new);
-      this.delegate = new ObjectArrayIterator<>(pathItems);
+      this.delegate = Arrays.stream(pathItems).iterator();
     }
   }
 

--- a/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
@@ -39,7 +39,6 @@ import java.util.UUID;
 import static java.util.Collections.singletonList;
 import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.EntityType.INSTANCE;
-import static org.folio.rest.jaxrs.model.EntityType.ITEM;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.EntityType.ORDER;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
@@ -186,7 +185,7 @@ public class MappingManagerUnitTest {
     for (MappingRule mappingRule : mappingProfile.getMappingDetails().getMappingFields()) {
       assertNotNull(mappingRule);
       assertTrue(mappingRule.getAcceptedValues().containsKey(organizationId));
-      String expectedAcceptedValue = String.format("%s (%s)", mappingRule.getValue().replaceAll("\"",""), organizationId);
+      String expectedAcceptedValue = String.format("%s (%s)", mappingRule.getValue().replaceAll("\"", ""), organizationId);
       assertEquals(expectedAcceptedValue, mappingRule.getAcceptedValues().get(organizationId));
     }
   }
@@ -253,23 +252,18 @@ public class MappingManagerUnitTest {
   }
 
   @Test
-  public void shouldMap_MarcBibliographicToInstanceStatisticalCodesFromMarcValue() {
+  public void shouldMap_MarcBibliographicToInstanceStatisticalCodesFromMultipleMarcFieldsByCode() {
     shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc", "bbc"), new Instance(), null, List.of(0, 1));
   }
 
   @Test
-  public void shouldMap_MarcBibliographicToHoldingsStatisticalCodeFromMarcValue() {
+  public void shouldMap_MarcBibliographicToHoldingsStatisticalCodeFromMarcFieldByName() {
     shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd"), new Holdings(), null, List.of(0));
   }
 
   @Test
-  public void shouldMap_MarcBibliographicToHoldingsStatisticalCode2FromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("bbd (bbc)"), new Holdings(), null, List.of(1));
-  }
-
-  @Test
-  public void shouldMap_MarcBibliographicToItemStatisticalCodeFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbc"), new Holdings(), null, List.of(1));
+  public void shouldMap_MarcBibliographicToInstanceStatisticalCodeFromMarcFieldByCode() {
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("bbc"), new Instance(), null, List.of(1));
   }
 
   @Test
@@ -280,13 +274,13 @@ public class MappingManagerUnitTest {
 
   @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCodesFromStringValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc", "bbc"), new Instance(),
+    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abc", "bbc"), new Holdings(),
       "\"TEST (test code type): abc - abd\"", List.of(0));
   }
 
   @Test
-  public void shouldMap_MarcBibliographicToHoldingsStatisticalCodesIfStringValueSpecifiedInElsePart() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("bbc"), new Holdings(),
+  public void shouldMap_MarcBibliographicToStatisticalCodesFromStringValueSpecifiedInElsePart() {
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("bbc"), new Instance(),
       "990$a; else \"TEST (test code type): abc - abd\"", List.of(0));
   }
 
@@ -343,12 +337,12 @@ public class MappingManagerUnitTest {
     List<JsonObject> parsedRecordContentFields = new ArrayList<>();
     for (String statisticalCodeValue : statisticalCodeValues) {
       JsonObject field = new JsonObject();
-      field.put("971",statisticalCodeValue);
+      field.put("971", statisticalCodeValue);
       parsedRecordContentFields.add(field);
     }
     JsonObject parsedRecordContent = new JsonObject();
-    parsedRecordContent.put("leader","01314nam  22003851a 4500");
-    parsedRecordContent.put("fields",parsedRecordContentFields);
+    parsedRecordContent.put("leader", "01314nam  22003851a 4500");
+    parsedRecordContent.put("fields", parsedRecordContentFields);
     ParsedRecord parsedRecord = new ParsedRecord()
       .withContent(parsedRecordContent.toString());
 
@@ -384,11 +378,11 @@ public class MappingManagerUnitTest {
     assertNotNull(eventPayload.getContext().get(MARC_BIBLIOGRAPHIC.value()));
     assertNotNull(eventPayload.getContext().get(entityType.value()));
 
-    Map<String,Object> entityResult = (Map) Json.decodeValue(eventPayload.getContext().get(entityType.value()), Map.class).get("instance");
-    List<String> statisticalCodeIds =(List) entityResult.get("statisticalCodeIds");
+    Map<String, Object> entityResult = (Map) Json.decodeValue(eventPayload.getContext().get(entityType.value()), Map.class).get("instance");
+    List<String> statisticalCodeIds = (List) entityResult.get("statisticalCodeIds");
     assertEquals(statisticalCodeIds.size(), expectedResultIndexes.size());
     for (int i = 0; i < expectedResultIndexes.size(); i++) {
-      assertEquals(statisticalCodes.get(expectedResultIndexes.get(i)).getId(),statisticalCodeIds.get(i));
+      assertEquals(statisticalCodes.get(expectedResultIndexes.get(i)).getId(), statisticalCodeIds.get(i));
     }
   }
 }

--- a/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
@@ -254,58 +254,62 @@ public class MappingManagerUnitTest {
 
   @Test
   public void shouldMap_MarcBibliographicToInstanceStatisticalCodesFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc","bbc"), new Instance(), null, null, List.of(0,1));
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc", "bbc"), new Instance(), null, List.of(0, 1));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToInstanceStatisticalCodeFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("bbd"), new Instance(), null, null, List.of(1));
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("bbd"), new Instance(), null, List.of(1));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCodeFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd"), new Holdings(), null, null, List.of(0));
+    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd"), new Holdings(), null, List.of(0));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCode1FromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd (abc)"), new Holdings(), null, null, List.of(0));
+    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd (abc)"), new Holdings(), null, List.of(0));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCode2FromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("bbd (bbc)"), new Holdings(), null, null, List.of(1));
+    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("bbd (bbc)"), new Holdings(), null, List.of(1));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToItemStatisticalCodeFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbc"), new Holdings(), null, null, List.of(1));
+    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbc"), new Holdings(), null, List.of(1));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToItemStatisticalCodesFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbd", "abd (abc)"), new Holdings(), null, null, List.of(1,0));
+    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbd", "abd (abc)"), new Holdings(), null, List.of(1, 0));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToInstanceStatisticalCodesFromStringValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc","bbc"), new Instance(), "\"test\"",
-      new HashMap<>(Map.of("uuid1", "test")), List.of(0));
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc", "bbc"), new Instance(),
+      "\"TEST (test code type): abc - abd\"", List.of(0));
   }
 
   @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCodesFromStringValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc","bbc"), new Holdings(), "\"test\"",
-      new HashMap<>(Map.of("uuid1", "test")), List.of(0));
+    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("abc", "bbc"), new Instance(),
+      "\"TEST (test code type): abc - abd\"", List.of(0));
   }
 
+  @Test
+  public void shouldMap_MarcBibliographicToHoldingsStatisticalCodesIfStringValueSpecifiedInElsePart() {
+    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("bbc"), new Holdings(),
+      "990$a; else \"TEST (test code type): abc - abd\"", List.of(0));
+  }
 
   private void shouldMap_MarcBibliographicStatisticalCodes(
     EntityType entityType,
     List<String> statisticalCodeValues,
     Object entityInstance,
     String value,
-    HashMap<String, String> acceptedValues,
     List<Integer> expectedResultIndexes
   ) {
     List<StatisticalCode> statisticalCodes = List.of(
@@ -318,6 +322,11 @@ public class MappingManagerUnitTest {
         .withCode("bbc")
         .withName("bbd (bbc)")
     );
+
+    HashMap<String, String> acceptedValues = new HashMap<>(Map.of(
+      "uuid1", "TEST (test code type): abc - abd",
+      "uuid2", "TEST (test code type): bbc - bbd (bbc)"));
+
     MappingProfile mappingProfile = new MappingProfile()
       .withId(UUID.randomUUID().toString())
       .withIncomingRecordType(MARC_BIBLIOGRAPHIC)

--- a/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/manager/MappingManagerUnitTest.java
@@ -258,18 +258,8 @@ public class MappingManagerUnitTest {
   }
 
   @Test
-  public void shouldMap_MarcBibliographicToInstanceStatisticalCodeFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(INSTANCE, List.of("bbd"), new Instance(), null, List.of(1));
-  }
-
-  @Test
   public void shouldMap_MarcBibliographicToHoldingsStatisticalCodeFromMarcValue() {
     shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd"), new Holdings(), null, List.of(0));
-  }
-
-  @Test
-  public void shouldMap_MarcBibliographicToHoldingsStatisticalCode1FromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(HOLDINGS, List.of("abd (abc)"), new Holdings(), null, List.of(0));
   }
 
   @Test
@@ -280,11 +270,6 @@ public class MappingManagerUnitTest {
   @Test
   public void shouldMap_MarcBibliographicToItemStatisticalCodeFromMarcValue() {
     shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbc"), new Holdings(), null, List.of(1));
-  }
-
-  @Test
-  public void shouldMap_MarcBibliographicToItemStatisticalCodesFromMarcValue() {
-    shouldMap_MarcBibliographicStatisticalCodes(ITEM, List.of("bbd", "abd (abc)"), new Holdings(), null, List.of(1, 0));
   }
 
   @Test

--- a/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
@@ -3,7 +3,10 @@ package org.folio.processing.mapping.mapper.reader.matcher;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class StatisticalCodeAcceptedValuesMatcherTest {
 
   private StatisticalCodeAcceptedValuesMatcher acceptedValuesMatcher = new StatisticalCodeAcceptedValuesMatcher();

--- a/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
@@ -1,0 +1,32 @@
+package org.folio.processing.mapping.mapper.reader.matcher;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StatisticalCodeAcceptedValuesMatcherTest {
+
+  private StatisticalCodeAcceptedValuesMatcher acceptedValuesMatcher = new StatisticalCodeAcceptedValuesMatcher();
+
+  @Test
+  public void shouldMatchByName() {
+    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
+    String codeName = "Archives (arch)";
+    Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, codeName));
+  }
+
+  @Test
+  public void shouldMatchByCode() {
+    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
+    String code = "arch";
+    Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, code));
+  }
+
+  @Test
+  public void shouldMatchByNameExcludingCode() {
+    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
+    String nameWithoutCodePart = "Archives";
+    Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, nameWithoutCodePart));
+  }
+
+}

--- a/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
@@ -9,17 +9,31 @@ public class StatisticalCodeAcceptedValuesMatcherTest {
   private StatisticalCodeAcceptedValuesMatcher acceptedValuesMatcher = new StatisticalCodeAcceptedValuesMatcher();
 
   @Test
-  public void shouldMatchByName() {
+  public void shouldMatchCaseSensitivelyByName() {
     String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
     String codeName = "Archives (arch)";
     Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, codeName));
   }
 
   @Test
-  public void shouldMatchByCode() {
+  public void shouldMatchCaseSensitivelyByCode() {
     String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
     String code = "arch";
     Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, code));
+  }
+
+  @Test
+  public void shouldNotMatchCaseInsensitivelyByName() {
+    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
+    String codeName = "archives (arch)";
+    Assert.assertFalse(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, codeName));
+  }
+
+  @Test
+  public void shouldNotMatchCaseInsensitivelyByCode() {
+    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
+    String code = "ARCH";
+    Assert.assertFalse(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, code));
   }
 
 }

--- a/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/reader/matcher/StatisticalCodeAcceptedValuesMatcherTest.java
@@ -22,11 +22,4 @@ public class StatisticalCodeAcceptedValuesMatcherTest {
     Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, code));
   }
 
-  @Test
-  public void shouldMatchByNameExcludingCode() {
-    String statisticalCodeAcceptedValue = "RECM (Record management): arch - Archives (arch)";
-    String nameWithoutCodePart = "Archives";
-    Assert.assertTrue(acceptedValuesMatcher.matches(statisticalCodeAcceptedValue, nameWithoutCodePart));
-  }
-
 }

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -1312,13 +1312,13 @@ public class MarcRecordReaderUnitTest {
 
     // then
     assertNotNull(valueVendor);
-    assertEquals(valueVendor.getType(), ValueType.MISSING);
+    assertEquals(ValueType.MISSING, valueVendor.getType());
 
     assertNotNull(valueMaterialSupplier);
-    assertEquals(valueMaterialSupplier.getType(), ValueType.MISSING);
+    assertEquals(ValueType.MISSING, valueMaterialSupplier.getType());
 
     assertNotNull(valueAccessProvider);
-    assertEquals(valueAccessProvider.getType(), ValueType.MISSING);
+    assertEquals(ValueType.MISSING, valueAccessProvider.getType());
   }
 
   @Test
@@ -1362,13 +1362,13 @@ public class MarcRecordReaderUnitTest {
 
     // then
     assertNotNull(valueVendor);
-    assertEquals(valueVendor.getValue(), uuid);
+    assertEquals(uuid, valueVendor.getValue());
 
     assertNotNull(valueMaterialSupplier);
-    assertEquals(valueMaterialSupplier.getValue(), uuid);
+    assertEquals(uuid, valueMaterialSupplier.getValue());
 
     assertNotNull(valueAccessProvider);
-    assertEquals(valueAccessProvider.getValue(), uuid);
+    assertEquals(uuid, valueAccessProvider.getValue());
   }
 
   @Test

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -27,8 +27,10 @@ import org.junit.runners.JUnit4;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,7 +68,6 @@ public class MarcRecordReaderUnitTest {
   private final String RECORD_WITH_MULTIPLE_028_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"2\",\"subfields\":[{\"a\":\"MCA2-4047\"},{\"b\":\"bMCA Records\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"DXSB7-156\"},{\"b\":\"Decca\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
 
   private final String RECORD_WITH_MULTIPLE_028_FIELDS_2 = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"2\",\"subfields\":[{\"a\":\"MCA2-4047\"},{\"b\":\"bMCA Records\"},{\"c\":\"Test1\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"1\",\"subfields\":[{\"a\":\"DXSB7-156\"},{\"b\":\"Decca\"},{\"c\":\"Test2\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"DXSB7-157\"},{\"b\":\"Decca2\"},{\"c\":\"Test3\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
-  private final String RECORD_WITH_SINGLE_028_FIELD = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"DXSB7-156\"},{\"b\":\"Decca\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
 
   private final String RECORD_WITH_THE_SAME_SUBFIELDS_IN_MULTIPLE_028_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aT90028\"},{\"b\":\"Verve\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aV-4061\"},{\"b\":\"Verve\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
   private final String RECORD_WITH_MULTIPLE_SUBFIELDS_IN_MULTIPLE_050_FIELD = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\": [{\"001\": \"009221\"}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"Z2013.5.W6\"}, {\"b\": \"K46 2018\"}, {\"a\": \"PR1286.W6\"}]}}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"a2-val\"}, {\"b\": \"b2-val\"}, {\"a\": \"a2-val\"}]}}, {\"245\": \"American Bar Association journal\"}]}";
@@ -684,7 +685,7 @@ public class MarcRecordReaderUnitTest {
     eventPayload.setContext(context);
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
-    String expectedDateString = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+    String expectedDateString = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(Instant.now());
 
     Value value = reader.read(new MappingRule()
       .withPath("")
@@ -708,7 +709,7 @@ public class MarcRecordReaderUnitTest {
 
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
-    String expectedDateString = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+    String expectedDateString = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(Instant.now());
 
     Value value = reader.read(new MappingRule()
       .withPath("")

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -84,7 +84,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("\"test\" \" \" \"value\""));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("\"test\" \" \" \"value\""));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -101,7 +101,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("LDR/4"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("LDR/4"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -118,7 +118,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("LDR/04"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("LDR/04"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -135,7 +135,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("LDR/4-5"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("LDR/4-5"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -152,7 +152,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("LDR/04-05"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("LDR/04-05"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -169,7 +169,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("001/4"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("001/4"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -186,7 +186,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("001/04"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("001/04"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -203,7 +203,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("001/4-5"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("001/4-5"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -220,7 +220,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("").withValue("001/04-05"));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("").withValue("001/04-05"));
     // then
     assertNotNull(value);
     assertEquals(ValueType.STRING, value.getType());
@@ -237,7 +237,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("[]").withValue("\"test\" \" \" \"value\""));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("[]").withValue("\"test\" \" \" \"value\""));
     // then
     assertNotNull(value);
     assertEquals(ValueType.LIST, value.getType());
@@ -254,7 +254,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     // when
-    Value value = reader.read(new MappingRule().withPath("[]").withValue("\" \";else \"value\""));
+    Value value = reader.read(new MappingRule().withName("testField").withPath("[]").withValue("\" \";else \"value\""));
     // then
     assertNotNull(value);
     assertEquals(ValueType.LIST, value.getType());
@@ -292,6 +292,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("randomUUID2", "noValue");
     // when
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("")
       .withValue("\"test\" \" \" \"value\" \" \"")
       .withAcceptedValues(acceptedValues));
@@ -331,6 +332,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("")
       .withValue("042$a \" \" 042$a"));
     // then
@@ -350,6 +352,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("")
       .withValue("042$3 \" \" 042$a"));
     // then
@@ -369,6 +372,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("[]")
       .withValue("042$a \" \" 042$a"));
     // then
@@ -391,6 +395,7 @@ public class MarcRecordReaderUnitTest {
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("")
       .withValue("043$a \" \"; else 010; else 042$a \" \" \"data\" \" \" 001; else 042$a"));
     // then
@@ -709,7 +714,7 @@ public class MarcRecordReaderUnitTest {
 
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
-    String expectedDateString = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(Instant.now());
+    String expectedDateString = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
 
     Value value = reader.read(new MappingRule()
       .withPath("")
@@ -788,6 +793,7 @@ public class MarcRecordReaderUnitTest {
     reader.initialize(eventPayload, mappingContext);
     // when
     Value value = reader.read(new MappingRule()
+      .withName("testField")
       .withPath("[]")
       .withValue("902$a 902$b 902$c 902$d"));
     // then
@@ -939,6 +945,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("f34d27c6-a8eb-461b-acd6-5dea81771e70", "SECOND FLOOR (KU/CC/DI/2)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -965,6 +972,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("f34d27c6-a8eb-461b-acd6-5dea81771e70", "SECOND FLOOR (KU/CC/DI/MU)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -990,6 +998,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("f34d27c6-a8eb-461b-acd6-5dea81771e70", "SECOND FLOOR (KU/CC/DI/VU)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -1016,6 +1025,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("f34d27c6-a8eb-461b-acd6-5dea81771e70", "SECOND FLOOR (KU/CC/DI/VU)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -1041,6 +1051,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("f34d27c6-a8eb-461b-acd6-5dea81771e70", "SECOND FLOOR (KU/CC/DI/VU)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -1067,6 +1078,7 @@ public class MarcRecordReaderUnitTest {
     acceptedValues.put("fcd64ce1-6995-48f0-840e-89ffa2288371", "Oli als (Oli)(oli,als)");
 
     Value value = reader.read(new MappingRule()
+      .withName("permanentLocationId")
       .withPath("holdings.permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
@@ -1094,6 +1106,7 @@ public class MarcRecordReaderUnitTest {
 
     Value value = reader.read(new MappingRule()
       .withPath("holdings.permanentLocationId")
+      .withName("permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
     assertNotNull(value);
@@ -1120,6 +1133,7 @@ public class MarcRecordReaderUnitTest {
 
     Value value = reader.read(new MappingRule()
       .withPath("holdings.permanentLocationId")
+      .withName("permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
     assertNotNull(value);
@@ -1146,6 +1160,7 @@ public class MarcRecordReaderUnitTest {
 
     Value value = reader.read(new MappingRule()
       .withPath("holdings.permanentLocationId")
+      .withName("permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
     assertNotNull(value);
@@ -1171,6 +1186,7 @@ public class MarcRecordReaderUnitTest {
 
     Value value = reader.read(new MappingRule()
       .withPath("holdings.permanentLocationId")
+      .withName("permanentLocationId")
       .withValue("049$a")
       .withAcceptedValues(acceptedValues));
     assertNotNull(value);
@@ -1379,22 +1395,22 @@ public class MarcRecordReaderUnitTest {
           .withOrder(0)
           .withPath("order.poLine.details.productIds[]")
           .withFields(List.of(
-            new MappingRule()
-              .withName("productId")
-              .withPath("order.poLine.details.productIds[].productId")
-              .withValue("020$a")
-              .withRequired(true)
-              .withEnabled("true"),
-            new MappingRule()
-              .withName("qualifier")
-              .withPath("order.poLine.details.productIds[].qualifier")
-              .withValue("020$q")
-              .withEnabled("true"),
-            new MappingRule()
-              .withName("productIdType")
-              .withPath("order.poLine.details.productIds[].productIdType")
-              .withValue("\"ISBN\"")
-              .withEnabled("true")
+              new MappingRule()
+                .withName("productId")
+                .withPath("order.poLine.details.productIds[].productId")
+                .withValue("020$a")
+                .withRequired(true)
+                .withEnabled("true"),
+              new MappingRule()
+                .withName("qualifier")
+                .withPath("order.poLine.details.productIds[].qualifier")
+                .withValue("020$q")
+                .withEnabled("true"),
+              new MappingRule()
+                .withName("productIdType")
+                .withPath("order.poLine.details.productIds[].productIdType")
+                .withValue("\"ISBN\"")
+                .withEnabled("true")
             )
           )
       ));
@@ -1641,6 +1657,7 @@ public class MarcRecordReaderUnitTest {
     reader.initialize(eventPayload, mappingContext);
 
     MappingRule callNumberRule = new MappingRule()
+      .withName("callNumber")
       .withPath("holdings.callNumber")
       .withEnabled("true")
       .withValue("050$a");


### PR DESCRIPTION
## Purpose
to fix statistical code mapping that includes 'else' in a field mapping profile, so that statistical code in the 'else' mapping statement has been applied if an incoming MARC record does not contain a MARC field providing statistical code data for mapping. 
In addition, statistical code and name comparison for accepted value determination needs to be changed to be case-sensitive.


## Approach
* change statistical code mapping logic to support statistical code mapping by code or full name retrieved from incoming MARC field, or using stat code specified in the 'else' part of mapping if there is no incoming MARC field containing statistical code data. Change logic for stat code accepted value determination to perform a case-sensitive comparison.
* add and update tests


## Learning
[MODDICORE-368](https://issues.folio.org/browse/MODDICORE-368)