### PR TITLE
MODINV-906: Fix Item creation when Statistical Code value is empty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * [MODDICORE-382](https://issues.folio.org/browse/MODDICORE-382) Remove from the payload extra key after Multiple Optimistic Locking error reveals
 * [MODSOURMAN-1022](https://issues.folio.org/browse/MODSOURMAN-1022) Remove step of initial saving of incoming records to SRS
 * [MODDICORE-370](https://issues.folio.org/browse/MODDICORE-370) Mapped administrative notes creates multiple notes properties instead of one note property
+* [MODINV-906](https://issues.folio.org/browse/MODINV-906) Create Item action discards when stat codes are in field mapping but not incoming MARC file
 
 ## 2023-XX-XX v4.1.3-SANPSHOT
 * [MODDICORE-368](https://issues.folio.org/browse/MODDICORE-368) 'else' statement in Field Mapping Profile for Statistical Code is ignored

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -340,6 +340,9 @@ public class MarcRecordReader implements Reader {
             repeatableStrings.add(readRepeatableStringField(mappingRule));
           } else {
             retrieveValuesFromMarcRecord(repeatableStrings, mappingRule);
+            if (repeatableStrings.isEmpty()) {
+              repeatableObjectItems.remove(object);
+            }
           }
         } else {
           Value value = mappingRule.getBooleanFieldAction() != null

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -664,6 +664,30 @@ public class MarcRecordReaderUnitTest {
   }
 
   @Test
+  public void shouldReturnEmptyRepeatableFieldValueWhenHasNoDataForRequiredFieldStatisticalCodeIds() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record().withParsedRecord(new ParsedRecord().withContent(RECORD))).encode());
+    eventPayload.setContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    MappingRule mappingRule = new MappingRule()
+      .withName("statisticalCodeIds").withPath("item.statisticalCodeIds[]").withValue("")
+      .withEnabled("true").withRepeatableFieldAction(EXTEND_EXISTING)
+      .withSubfields(
+        List.of(new RepeatableSubfieldMapping().withOrder(0).withPath("item.statisticalCodeIds[]")
+          .withFields(
+            List.of(new MappingRule().withName("statisticalCodeId").withEnabled("true").withPath("item.statisticalCodeIds[]")
+              .withEnabled("true").withValue("949$s").withAcceptedValues(new HashMap<>())))));
+    Value value = reader.read(mappingRule);
+
+    assertNotNull(value);
+    assertEquals(ValueType.REPEATABLE, value.getType());
+    assertTrue(((RepeatableFieldValue) value).getValue().isEmpty());
+  }
+
+  @Test
   public void shouldReadRepeatableFieldsIfSubfieldsAreEmptyAndActionIsEmpty() throws IOException {
     DataImportEventPayload eventPayload = new DataImportEventPayload();
     HashMap<String, String> context = new HashMap<>();


### PR DESCRIPTION
## Purpose
Fix Item creation when Statistical Code value is empty

## Approach
Remove hardcoded empty object when retrieved value is MissingValue

#### Tesed locally

<img width="1292" alt="image" src="https://github.com/folio-org/data-import-processing-core/assets/138673581/1a80ed16-9ca8-40fa-8bf6-e404a38ebb9e">


## Learning
[MODINV-906](https://issues.folio.org/browse/MODINV-906)
