### PR TITLE
MODSOURMAN-1115 Accomodate for authority-source-files api changes

### DIFF
--- a/ramls/settings/authoritysourcefile.json
+++ b/ramls/settings/authoritysourcefile.json
@@ -32,7 +32,8 @@
       "description": "label indicating where the authority source file entry originates from, i.e. 'folio' or 'local'",
       "enum": [
         "folio",
-        "local"
+        "local",
+        "consortium"
       ]
     },
     "selectable": {


### PR DESCRIPTION
## Purpose
Accomodate for authority-source-files api changes

## Approach
Add 'consortium' to source enum of authority-source-file dto

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
[MODSOURMAN-1115](https://issues.folio.org/browse/MODSOURMAN-1115)
