### PR TITLE
MODDATAIMP-979 - Updated authoritysourcefile schema with consortium value

### DIFF
--- a/ramls/settings/authoritysourcefile.json
+++ b/ramls/settings/authoritysourcefile.json
@@ -32,7 +32,8 @@
       "description": "label indicating where the authority source file entry originates from, i.e. 'folio' or 'local'",
       "enum": [
         "folio",
-        "local"
+        "local",
+        "consortium"
       ]
     },
     "selectable": {


### PR DESCRIPTION
## Purpose
update authoritysourcefile  schema to fix import on the consortia sprint testing env