### PR TITLE
MODSOURMAN-1116 Accomodate for authority-source-files api optimistic locking changes

### DIFF
--- a/ramls/settings/authoritysourcefile.json
+++ b/ramls/settings/authoritysourcefile.json
@@ -50,6 +50,10 @@
         }
       }
     },
+    "_version": {
+      "type": "integer",
+      "description": "Record version for optimistic locking"
+    },
     "metadata": {
       "type": "object",
       "$ref": "../raml-storage/raml-util/schemas/metadata.schema",

--- a/ramls/settings/authoritysourcefile.json
+++ b/ramls/settings/authoritysourcefile.json
@@ -60,7 +60,6 @@
       "readonly": true
     }
   },
-  "additionalProperties": false,
   "required": [
     "name",
     "code",


### PR DESCRIPTION
## Purpose
Accomodate for authority-source-files api optimistic locking changes

## Approach
Add _version field to authoritysourcefile

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
