### PR TITLE
MODDICORE-388 Allow to map vendor details with code that contains brackets during order creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2024-xx-xx v4.3.0
+* [MODDICORE-388](https://folio-org.atlassian.net/browse/MODDICORE-388) Allow to map vendor details with code that contains brackets during order creation
+
 ## 2024-03-18 v4.2.0
 * [MODDICORE-398](https://issues.folio.org/browse/MODDICORE-398) Update RMB v35.2.0, Vertx 4.5.4
 * [MODSOURMAN-1085](https://issues.folio.org/browse/MODSOURMAN-1085) MARC record with a 100 tag without a $a is being discarded on import.

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -245,7 +245,7 @@ public class MarcRecordReader implements Reader {
         return true;
       } else if (retrieveStringWithBracketsFromLastOne(mappingParameter).equalsIgnoreCase(value)) {
         return true;
-      } else if (retrieveNameWithoutCode(mappingParameter).equalsIgnoreCase(value)) {
+      } else if (retrieveNameWithoutBrackets(mappingParameter).equalsIgnoreCase(value)) {
         return true;
       }
       return false;
@@ -263,23 +263,31 @@ public class MarcRecordReader implements Reader {
     return mappingParameter.substring(mappingParameter.indexOf(FIRST_BRACKET), mappingParameter.indexOf(SECOND_BRACKET) + 1);
   }
 
-  private String retrieveNameWithoutCode(String mappingParameter) {
+  private String retrieveNameWithoutBrackets(String mappingParameter) {
     mappingParameter = mappingParameter.trim();
-    int start = 0, end = mappingParameter.length();
 
-    if (mappingParameter.startsWith(FIRST_BRACKET)) {
-      start++;
-    }
+    int startIndex = mappingParameter.startsWith(FIRST_BRACKET) ? 1 : 0;
 
-    for (int i = start; i < end; i++) {
-      char c = mappingParameter.charAt(i);
+    int endIndex = findFirstParenthesesIndex(mappingParameter, startIndex);
+
+    return mappingParameter.substring(startIndex, endIndex).trim();
+  }
+
+  /**
+   * Finds the index of the first occurrence of either bracket starting from the given index.
+   * Returns the input string's length if no brackets are found.
+   * @param input             mapping parameter
+   * @param startIndex        start index of code without parentheses
+   * @return index of first occured parentheses in mapping parameter
+   */
+  private int findFirstParenthesesIndex(String input, int startIndex) {
+    for (int i = startIndex; i < input.length(); i++) {
+      char c = input.charAt(i);
       if (c == FIRST_BRACKET.charAt(0) || c == SECOND_BRACKET.charAt(0)) {
-        end = i;
-        break;
+        return i;
       }
     }
-
-    return mappingParameter.substring(start, end).trim();
+    return input.length();
   }
 
   /**

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -258,11 +258,28 @@ public class MarcRecordReader implements Reader {
   }
 
   private String retrieveStringWithBracketsFromLastOne(String mappingParameter) {
+    if (mappingParameter.indexOf(FIRST_BRACKET) > mappingParameter.indexOf(SECOND_BRACKET))
+      return mappingParameter.substring(mappingParameter.indexOf(FIRST_BRACKET), mappingParameter.lastIndexOf(SECOND_BRACKET) + 1);
     return mappingParameter.substring(mappingParameter.indexOf(FIRST_BRACKET), mappingParameter.indexOf(SECOND_BRACKET) + 1);
   }
 
   private String retrieveNameWithoutCode(String mappingParameter) {
-    return mappingParameter.substring(0, mappingParameter.trim().indexOf(FIRST_BRACKET) - 1);
+    mappingParameter = mappingParameter.trim();
+    int start = 0, end = mappingParameter.length();
+
+    if (mappingParameter.startsWith(FIRST_BRACKET)) {
+      start++;
+    }
+
+    for (int i = start; i < end; i++) {
+      char c = mappingParameter.charAt(i);
+      if (c == FIRST_BRACKET.charAt(0) || c == SECOND_BRACKET.charAt(0)) {
+        end = i;
+        break;
+      }
+    }
+
+    return mappingParameter.substring(start, end).trim();
   }
 
   /**

--- a/src/test/java/org/folio/processing/events/services/publisher/KafkaEventPublisherTest.java
+++ b/src/test/java/org/folio/processing/events/services/publisher/KafkaEventPublisherTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class KafkaEventPublisherTest {
-  private static final String KAFKA_ENV = "test-env";
+  private static final String KAFKA_ENV = "folio";
   private static final String OKAPI_URL = "http://localhost";
   private static final String TENANT_ID = "diku";
   private static final String TOKEN = "stub-token";

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -1440,6 +1440,37 @@ public class MarcRecordReaderUnitTest {
   }
 
   @Test
+  public void shouldRead_IfVendorCodeContainsParenthesis() throws IOException {
+    // given
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD))).encode());
+    eventPayload.setContext(context);
+
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+    String uuid = "UUID";
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put(uuid, String.format("(CODE) (%s)", uuid));
+
+    MappingRule vendorRule = new MappingRule()
+      .withName("vendor")
+      .withPath("order.po.vendor")
+      .withEnabled("true")
+      .withValue("\"CODE\"")
+      .withAcceptedValues(acceptedValues);
+
+    // when
+    Value valueVendor = reader.read(vendorRule);
+
+    // then
+    assertNotNull(valueVendor);
+    assertEquals(uuid, valueVendor.getValue());
+  }
+
+
+  @Test
   public void shouldReturnEmptyRepeatableFieldValueWhenHasNoDataForRequiredFieldProductId() throws IOException {
     // given
     DataImportEventPayload eventPayload = new DataImportEventPayload();


### PR DESCRIPTION
## Purpose
[MODDICORE-388](https://folio-org.atlassian.net/browse/MODDICORE-388) Allow to map vendor details with code that contains brackets during order creation

## Approach
remove unnecessary parentheses

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
