### PR TITLE
MODDICORE-405 Optimize record processing and close kafka producer app…

### DIFF
--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Escaper.java
@@ -2,11 +2,14 @@ package org.folio.processing.mapping.defaultmapper.processor;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.regex.Pattern;
+
 /**
  * Escape text so that it is valid json as well as valid postgres jsonb data
  *
  */
 public class Escaper {
+  private static final Pattern ESCAPED_DOUBLE_QUOTES = Pattern.compile("\\\"");
 
   private static String removeEscapedChars(String text) {
     int len = text.length();
@@ -71,7 +74,7 @@ public class Escaper {
     if (!keepTrailingBackslash && data.endsWith("\\")) {
       data = data.substring(0, data.length() - 1);
     }
-    data = removeEscapedChars(data).replaceAll("\\\"", "\\\\\"");
+    data = ESCAPED_DOUBLE_QUOTES.matcher(removeEscapedChars(data)).replaceAll("\\\\\"");
     return data;
   }
 

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
@@ -34,8 +34,8 @@ public class LoaderHelper {
       // something like - marc.identifier -> identifierObject.idField
       if (type.isAssignableFrom(java.util.List.class)
         || type.isAssignableFrom(java.util.Set.class)) {
-        Class<?> listTypeClass = LIST_TYPE_CLASS_CACHE.computeIfAbsent(field, field1 -> {
-          ParameterizedType listType = (ParameterizedType) field.getGenericType();
+        Class<?> listTypeClass = LIST_TYPE_CLASS_CACHE.computeIfAbsent(field, newField -> {
+          ParameterizedType listType = (ParameterizedType) newField.getGenericType();
           return (Class<?>) listType.getActualTypeArguments()[0];
         });
         object = listTypeClass.newInstance();

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
@@ -8,10 +8,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class LoaderHelper {
 
   private static final Logger LOGGER = LogManager.getLogger(LoaderHelper.class);
+  private static final Map<Field, Class<?>> LIST_TYPE_CLASS_CACHE = new ConcurrentHashMap<>();
   private LoaderHelper() {}
 
   public static boolean isMappingValid(Object object, String[] path)
@@ -31,8 +34,10 @@ public class LoaderHelper {
       // something like - marc.identifier -> identifierObject.idField
       if (type.isAssignableFrom(java.util.List.class)
         || type.isAssignableFrom(java.util.Set.class)) {
-        ParameterizedType listType = (ParameterizedType) field.getGenericType();
-        Class<?> listTypeClass = (Class<?>) listType.getActualTypeArguments()[0];
+        Class<?> listTypeClass = LIST_TYPE_CLASS_CACHE.computeIfAbsent(field, field1 -> {
+          ParameterizedType listType = (ParameterizedType) field.getGenericType();
+          return (Class<?>) listType.getActualTypeArguments()[0];
+        });
         object = listTypeClass.newInstance();
         if (isPrimitiveOrPrimitiveWrapperOrString(listTypeClass) && i == path.length - 1) {
           // we are here if the last entry in the path is an array / set of primitives, that is ok

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -868,7 +868,7 @@ public class Processor<T> {
   }
 
   private static ParameterizedType getParameterizedType(Field field) {
-    return PARAM_TYPE_CACHE.computeIfAbsent(field, (fieldobj) -> (ParameterizedType)fieldobj.getGenericType());
+    return PARAM_TYPE_CACHE.computeIfAbsent(field, (fieldObj) -> (ParameterizedType)fieldObj.getGenericType());
   }
 
   private static Object setObjectCorrectly(boolean newComp, Class<?> listTypeClass, Class<?> type, String pathSegment,


### PR DESCRIPTION
## Purpose
Optimize used code paths and close kafka producer appropriately.

## Approach
Reflection is used heavily during processing of records. Class, Field and Method retrieval is expensive so when they are processed, they are cached.

One change involves recompiling a regex pattern on each invocation. The compiled pattern is cached.

A kafka producer is in this library is open and closed repeatedly. Although the kafka producer is shared, it is closed before the next message production is ready. This is causing thrashing of the producer; created and the deleted. The fix was to delay the closing of the producer so that the shared producer can be handed off for other invocations.
