### PR TITLE
MODDICORE-406: Relationship ID incorrect mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## 2024-xx-xx v4.3.0
 * [MODDICORE-388](https://folio-org.atlassian.net/browse/MODDICORE-388) Allow to map vendor details with code that contains brackets during order creation
 * [MODSOURMAN-1120](https://folio-org.atlassian.net/browse/MODSOURMAN-1120) Update default mapping to include mapping for Cancelled LCCN
+* [MODDICORE-406](https://folio-org.atlassian.net/browse/MODDICORE-406) Relationship ID incorrect mapping
+
 
 ## 2024-03-18 v4.2.0
 * [MODDICORE-398](https://issues.folio.org/browse/MODDICORE-398) Update RMB v35.2.0, Vertx 4.5.4

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -83,7 +83,7 @@ public class MarcRecordReader implements Reader {
   private static final String TIMEZONE_PROPERTY = "timezone";
   private static final String DATE_TIME_FORMAT = "dd-MM-yyyy HH:mm:ss";
   private static final String UTC_TIMEZONE = "UTC";
-  private static final List<String> NEEDS_VALIDATION_BY_ACCEPTED_VALUES = List.of("vendor", "materialSupplier", "accessProvider");
+  private static final List<String> NEEDS_VALIDATION_BY_ACCEPTED_VALUES = List.of("vendor", "materialSupplier", "accessProvider","relationshipId");
   private static final String STATISTICAL_CODE_ID_FIELD = "statisticalCodeId";
   private static final String BLANK = "";
 

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -494,23 +494,31 @@ public class MarcRecordReaderUnitTest {
     eventPayload.setContext(context);
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
+
+    String uuid = "f5d0068e-6272-458e-8a81-b85e7b9a14aa";
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put(uuid, String.format("Resource (%s)", uuid));
+
     List<MappingRule> listRules = new ArrayList<>();
 
     listRules.add(new MappingRule()
       .withName("uri")
       .withPath("holdings.electronicAccess[].uri")
       .withEnabled("true")
-      .withValue("856$u"));
+      .withValue("856$u")
+      .withAcceptedValues(acceptedValues));
     listRules.add(new MappingRule()
       .withName("relationshipId")
       .withPath("holdings.electronicAccess[].relationshipId")
       .withEnabled("true")
-      .withValue("\"f5d0068e-6272-458e-8a81-b85e7b9a14aa\""));
+      .withValue("\"f5d0068e-6272-458e-8a81-b85e7b9a14aa\"")
+      .withAcceptedValues(acceptedValues));
     listRules.add(new MappingRule()
       .withName("linkText")
       .withPath("holdings.electronicAccess[].linkText")
       .withEnabled("true")
-      .withValue("856$z"));
+      .withValue("856$z")
+      .withAcceptedValues(acceptedValues));
 
     Value value = reader.read(new MappingRule()
       .withName("electronicAccess")

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -15,6 +15,7 @@ import org.folio.processing.mapping.mapper.reader.Reader;
 import org.folio.processing.mapping.mapper.reader.record.marc.MarcBibReaderFactory;
 import org.folio.processing.value.BooleanValue;
 import org.folio.processing.value.ListValue;
+import org.folio.processing.value.MissingValue;
 import org.folio.processing.value.RepeatableFieldValue;
 import org.folio.processing.value.StringValue;
 import org.folio.processing.value.Value;
@@ -539,7 +540,7 @@ public class MarcRecordReaderUnitTest {
   }
 
   @Test
-  public void shouldLeftAnEmptyIfRelationShipIdIsInvalid() throws IOException {
+  public void shouldLeftAnEmptyValueIfRelationShipIdIsInvalid() throws IOException {
     DataImportEventPayload eventPayload = new DataImportEventPayload();
     HashMap<String, String> context = new HashMap<>();
     context.put(MARC_BIBLIOGRAPHIC.value(), JsonObject.mapFrom(new Record()
@@ -591,12 +592,12 @@ public class MarcRecordReaderUnitTest {
 
     Map<String, Value> object1 = new HashMap<>();
     object1.put("holdings.electronicAccess[].uri", StringValue.of("https://fod.infobase.com"));
-    object1.put("holdings.electronicAccess[].relationshipId", StringValue.of("Resourcce"));
+    object1.put("holdings.electronicAccess[].relationshipId", MissingValue.getInstance());
     object1.put("holdings.electronicAccess[].linkText", StringValue.of("image"));
 
     Map<String, Value> object2 = new HashMap<>();
     object2.put("holdings.electronicAccess[].uri", StringValue.of("https://cfvod.kaltura.com"));
-    object2.put("holdings.electronicAccess[].relationshipId", StringValue.of("Resourcce"));
+    object2.put("holdings.electronicAccess[].relationshipId", MissingValue.getInstance());
     object2.put("holdings.electronicAccess[].linkText", StringValue.of("films collection"));
 
     assertEquals(JsonObject.mapFrom(RepeatableFieldValue.of(Arrays.asList(object1, object2), EXTEND_EXISTING, "holdings")), JsonObject.mapFrom(value));


### PR DESCRIPTION
## Purpose
The main goal is to left "relationshipId"-field as empty if the value is invalid (can't map via acceptedValues.)

## Approach
Added "relationshipId" to the 'NEEDS_VALIDATION_BY_ACCEPTED_VALUES'-list.

## Learning
JIRA: https://folio-org.atlassian.net/browse/MODDICORE-406
