### PR TITLE
MODDICORE-413 - Adjust mapping of order to fill in donor information

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * [MODINV-709](https://folio-org.atlassian.net/browse/MODINV-709) Job profile with POL/VRN match cascade does not finish properly
 * [MODDICORE-408](https://folio-org.atlassian.net/browse/MODDICORE-408) Data Import removes duplicate 856s in SRS
 * [MODINV-1071](https://folio-org.atlassian.net/browse/MODINV-1071) Extend Authority with Additional fields
+* [MODDICORE-413](https://folio-org.atlassian.net/browse/MODDICORE-413) Adjust mapping of order to fill in donor information
 
 
 ## 2024-03-18 v4.2.0

--- a/src/main/java/org/folio/processing/mapping/MappingManager.java
+++ b/src/main/java/org/folio/processing/mapping/MappingManager.java
@@ -121,10 +121,9 @@ public final class MappingManager {
       HashMap<String, String> donorOrganizations = getDonorOrganizationsFromMappingParameters(mappingParameters);
       if (!organizations.isEmpty()) {
         for (MappingRule mappingRule : mappingProfile.getMappingDetails().getMappingFields()) {
-          if ((mappingRule.getName() != null) && (mappingRule.getName().equals(VENDOR_ID)
-            || mappingRule.getName().equals(MATERIAL_SUPPLIER) || mappingRule.getName().equals(ACCESS_PROVIDER))) {
+          if (isOrganizationsAcceptedValuesNeeded(mappingRule)) {
             mappingRule.setAcceptedValues(organizations);
-          } else if (mappingRule.getName().equals(DONOR_ORGANIZATION_IDS)) {
+          } else if (DONOR_ORGANIZATION_IDS.equals(mappingRule.getName())) {
             populateDonorOrganizations(mappingRule, donorOrganizations);
           }
         }
@@ -166,6 +165,11 @@ public final class MappingManager {
       .append(organization.getId())
       .append(")")
       .toString();
+  }
+
+  private static boolean isOrganizationsAcceptedValuesNeeded(MappingRule mappingRule) {
+    return (mappingRule.getName() != null) && (mappingRule.getName().equals(VENDOR_ID)
+      || mappingRule.getName().equals(MATERIAL_SUPPLIER) || mappingRule.getName().equals(ACCESS_PROVIDER));
   }
 
   private static void populateDonorOrganizations(MappingRule mappingRule, HashMap<String, String> donorOrganizations) {

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -83,7 +83,7 @@ public class MarcRecordReader implements Reader {
   private static final String TIMEZONE_PROPERTY = "timezone";
   private static final String DATE_TIME_FORMAT = "dd-MM-yyyy HH:mm:ss";
   private static final String UTC_TIMEZONE = "UTC";
-  private static final List<String> NEEDS_VALIDATION_BY_ACCEPTED_VALUES = List.of("vendor", "materialSupplier", "accessProvider","relationshipId");
+  private static final List<String> NEEDS_VALIDATION_BY_ACCEPTED_VALUES = List.of("vendor", "materialSupplier", "accessProvider","relationshipId", "donorOrganizationIds");
   private static final String STATISTICAL_CODE_ID_FIELD = "statisticalCodeId";
   private static final String BLANK = "";
 

--- a/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/reader/record/marc/MarcRecordReader.java
@@ -407,14 +407,7 @@ public class MarcRecordReader implements Reader {
 
   private String readRepeatableStringField(MappingRule mappingRule) {
     String value = mappingRule.getValue().replace(EXPRESSIONS_QUOTE, EMPTY);
-    if (MapUtils.isNotEmpty(mappingRule.getAcceptedValues())) {
-      for (Map.Entry<String, String> entry : mappingRule.getAcceptedValues().entrySet()) {
-        if (entry.getValue().equals(value)) {
-          value = entry.getKey();
-        }
-      }
-    }
-    return value;
+    return getFromAcceptedValues(mappingRule, value);
   }
 
   private boolean shouldCreateItemPerRepeatedMarcField(Value.ValueType valueType, MappingRule mappingRule) {

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -815,7 +815,7 @@ public class MarcRecordReaderUnitTest {
 
     Reader reader = new MarcBibReaderFactory().createReader();
     reader.initialize(eventPayload, mappingContext);
-    String expectedDateString = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
+    String expectedDateString = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC).format(Instant.now());
 
     Value value = reader.read(new MappingRule()
       .withPath("")

--- a/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
+++ b/src/test/java/org/folio/processing/mapping/reader/MarcRecordReaderUnitTest.java
@@ -47,6 +47,8 @@ import static org.folio.rest.jaxrs.model.EntityType.HOLDINGS;
 import static org.folio.rest.jaxrs.model.EntityType.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.DELETE_EXISTING;
 import static org.folio.rest.jaxrs.model.MappingRule.RepeatableFieldAction.EXTEND_EXISTING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -74,6 +76,7 @@ public class MarcRecordReaderUnitTest {
   private final String RECORD_WITH_THE_SAME_SUBFIELDS_IN_MULTIPLE_028_FIELDS = "{\"leader\":\"01314nam  22003851a 4500\",\"fields\":[{\"001\":\"009221\"},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aT90028\"},{\"b\":\"Verve\"}]}},{\"028\":{\"ind1\":\"0\",\"ind2\":\"0\",\"subfields\":[{\"a\":\"aV-4061\"},{\"b\":\"Verve\"}]}},{\"042\":{\"ind1\":\" \",\"ind2\":\" \",\"subfields\":[{\"a\":\"pcc\"}]}},{\"245\":\"American Bar Association journal\"}]}";
   private final String RECORD_WITH_MULTIPLE_SUBFIELDS_IN_MULTIPLE_050_FIELD = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\": [{\"001\": \"009221\"}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"Z2013.5.W6\"}, {\"b\": \"K46 2018\"}, {\"a\": \"PR1286.W6\"}]}}, {\"050\": {\"ind1\": \"0\", \"ind2\": \"0\", \"subfields\": [{\"a\": \"a2-val\"}, {\"b\": \"b2-val\"}, {\"a\": \"a2-val\"}]}}, {\"245\": \"American Bar Association journal\"}]}";
   private final String RECORD_WITH_980_FIELD = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\": [{\"001\": \"009221\"}, {\"245\": \"American Bar Association journal\"}, {\"980\": {\"ind1\": \"0\", \"ind2\": \"2\", \"subfields\": [{\"a\": \"00001\"}, {\"b\": \"Vendor order number\"}]}}]}";
+  private final String RECORD_WITH_900_FIELD_DONORS_CODES = "{\"leader\": \"01314nam  22003851a 4500\", \"fields\": [{\"001\": \"009221\"}, {\"900\": {\"ind1\": \"0\", \"ind2\": \"2\", \"subfields\": [{\"a\": \"CODE-1\"}, {\"b\": \"CODE-2\"}]}}]}";
 
   private MappingContext mappingContext = new MappingContext();
 
@@ -1992,6 +1995,93 @@ public class MarcRecordReaderUnitTest {
     assertEquals(2, ((ListValue) value).getValue().size());
     assertEquals("00001", ((ListValue) value).getValue().get(0));
     assertEquals("Vendor order number", ((ListValue) value).getValue().get(1));
+  }
+
+  @Test
+  public void shouldReturnListValueWithMultipleDonorsIdsIfMarcFieldMappingSpecified() throws IOException {
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD_WITH_900_FIELD_DONORS_CODES))));
+
+    DataImportEventPayload eventPayload = new DataImportEventPayload().withContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    String expectedId1 = "UUID1";
+    String expectedId2 = "UUID2";
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put(expectedId1, "(CODE-1) " + expectedId1);
+    acceptedValues.put(expectedId2, "(CODE-2) " + expectedId2);
+
+    MappingRule donorsMappingRule = new MappingRule()
+      .withName("donorOrganizationIds")
+      .withEnabled("true")
+      .withPath("order.poLine.donorOrganizationIds[]")
+      .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+      .withSubfields(List.of(
+        new RepeatableSubfieldMapping()
+          .withOrder(0)
+          .withPath("order.poLine.donorOrganizationIds[]")
+          .withFields(List.of(new MappingRule()
+            .withName("donorOrganizationIds")
+            .withEnabled("true")
+            .withPath("order.poLine.donorOrganizationIds[]")
+            .withValue("900$a")
+            .withAcceptedValues(acceptedValues))),
+        new RepeatableSubfieldMapping()
+          .withOrder(1)
+          .withPath("order.poLine.donorOrganizationIds[]")
+          .withFields(List.of(new MappingRule()
+            .withName("donorOrganizationIds")
+            .withEnabled("true")
+            .withPath("order.poLine.donorOrganizationIds[]")
+            .withValue("900$b")
+            .withAcceptedValues(acceptedValues)))
+      ));
+
+    Value<?> value = reader.read(donorsMappingRule);
+
+    assertNotNull(value);
+    assertEquals(ValueType.LIST, value.getType());
+    ListValue actualValue = (ListValue) value;
+    assertEquals(EXTEND_EXISTING, actualValue.getRepeatableFieldAction());
+    assertEquals(2, actualValue.getValue().size());
+    assertThat(actualValue.getValue(), contains(expectedId1, expectedId2));
+  }
+
+  @Test
+  public void shouldReturnEmptyRepeatableFieldValueIfMappingValueDoesNotMatchAcceptedValues() throws IOException {
+    DataImportEventPayload eventPayload = new DataImportEventPayload();
+    HashMap<String, String> context = new HashMap<>();
+    context.put(MARC_BIBLIOGRAPHIC.value(), Json.encode(new Record()
+      .withParsedRecord(new ParsedRecord().withContent(RECORD_WITH_900_FIELD_DONORS_CODES))));
+    eventPayload.setContext(context);
+    Reader reader = new MarcBibReaderFactory().createReader();
+    reader.initialize(eventPayload, mappingContext);
+
+    HashMap<String, String> acceptedValues = new HashMap<>();
+    acceptedValues.put("UUID3", "(CODE-3) UUID3");
+
+    MappingRule donorsMappingRule = new MappingRule()
+      .withName("donorOrganizationIds")
+      .withEnabled("true")
+      .withPath("order.poLine.donorOrganizationIds[]")
+      .withRepeatableFieldAction(MappingRule.RepeatableFieldAction.EXTEND_EXISTING)
+      .withSubfields(List.of(new RepeatableSubfieldMapping()
+        .withOrder(0)
+        .withPath("order.poLine.donorOrganizationIds[]")
+        .withFields(List.of(new MappingRule()
+          .withName("donorOrganizationIds")
+          .withEnabled("true")
+          .withPath("order.poLine.donorOrganizationIds[]")
+          .withValue("900$a")
+          .withAcceptedValues(acceptedValues)))));
+
+    Value<?> value = reader.read(donorsMappingRule);
+
+    assertNotNull(value);
+    assertEquals(ValueType.REPEATABLE, value.getType());
+    assertTrue(((RepeatableFieldValue) value).getValue().isEmpty());
   }
 
   private JsonObject createSubField(String name, String value) {


### PR DESCRIPTION
## Purpose
support po line "donorOrganizationIds" field mapping when MARC field mapping syntax set

## Approach
* populate mapping profile with donor organizations' data
* add check for "donorOrganizationIds" field to return empty value in case incoming value does not match existing organization data
* add tests


## Learning
[MODDICORE-413](https://issues.folio.org/browse/MODDICORE-413)
