### PR TITLE
[MODINV-1071] Extended authorities mapping for Quesnelia

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODDICORE-395](https://folio-org.atlassian.net/browse/MODDICORE-395) Allow creating multiple holdings/items when conditional mapping is used in field mapping profiles
 * [MODDICORE-392](https://folio-org.atlassian.net/browse/MODDICORE-392) "MARC authority" record is assigned to authority file if record's prefix includes prefix of authority file
 * [MODDICORE-390](https://folio-org.atlassian.net/browse/MODDICORE-390) Create Item action discards when stat codes are in field mapping but not incoming MARC file
+  [MODINV-1071](https://folio-org.atlassian.net/browse/MODINV-1071) Extend Authority with Additional fields
 
 ## 2023-10-11 v4.1.0
 * [MODDICORE-360](https://issues.folio.org/browse/MODDICORE-360) Migrate to folio-kafka-wrapper 3.0.0 version

--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ MappingManager calls Mapper to perform the mapping itself. Steps:
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
 * Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+
+## Extended Authority Mapping
+There is an extended Authority Mapping introduced to support advanced references classification in 5xx fields:
+* broader terms (`$wg` tag)
+* narrower terms (`$wh` tag)
+* earlier headings (`$wa` tag)
+* later headings (`$wb` tag)
+
+To support this functionality `AuthorityExtended` is used together with `MarkToAuthorityExtendedMapper`.

--- a/pom.xml
+++ b/pom.xml
@@ -267,10 +267,12 @@
                 <path>${basedir}/ramls/raml-storage/schemas/dto/edifactParsedContent.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/instanceLinkDtoCollection.json</path>
                 <path>${basedir}/ramls/raml-storage/schemas/mod-entities-links/linkingRuleDto.json</path>
+                <path>${basedir}/ramls/relatedHeading.json</path>
                 <path>${basedir}/ramls/event.json</path>
                 <path>${basedir}/ramls/instance.json</path>
                 <path>${basedir}/ramls/holdings.json</path>
                 <path>${basedir}/ramls/authority.json</path>
+                <path>${basedir}/ramls/authorityExtended.json</path>
                 <path>${basedir}/ramls/settings/alternativetitletypes.json</path>
                 <path>${basedir}/ramls/settings/classificationtypes.json</path>
                 <path>${basedir}/ramls/settings/contributornametypes.json</path>

--- a/ramls/authorityExtended.json
+++ b/ramls/authorityExtended.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An extended authority record",
+  "type": "object",
+  "extends": {
+    "$ref": "authority.json"
+  },
+  "properties": {
+    "saftBroaderTerm": {
+      "type": "array",
+      "description": "See also from tracing term that represents broader, more general concepts related to the authority record",
+      "items": {
+        "$ref": "relatedHeading.json"
+      }
+    },
+    "saftNarrowerTerm": {
+      "type": "array",
+      "description": "See also from tracing term that represents narrower, more specific concepts derived from the authority record",
+      "items": {
+        "$ref": "relatedHeading.json"
+      }
+    },
+    "saftEarlierHeading": {
+      "type": "array",
+      "description": "See also from tracing heading that was previously used to represent the concept or entity described by the authority record. This field is used to track the evolution of terms or headings over time, facilitating the linking of historical and current data.",
+      "items": {
+        "$ref": "relatedHeading.json"
+      }
+    },
+    "saftLaterHeading": {
+      "type": "array",
+      "description": "See also from tracing heading that replaced the current heading used in the authority record. This field helps in maintaining the continuity of catalog records by linking past headings to their more current versions.",
+      "items": {
+        "$ref": "relatedHeading.json"
+      }
+    }
+  }
+}

--- a/ramls/relatedHeading.json
+++ b/ramls/relatedHeading.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Related heading for BroaderTerm/NarrowerTerm/LaterHeading/EarlierHeading",
+  "type": "object",
+  "properties": {
+    "headingRef": {
+      "type": "string",
+      "description": "HeadingRef value"
+    },
+    "headingType": {
+      "type": "string",
+      "description": "Heading type"
+    }
+  },
+  "required": [
+    "headingRef",
+    "headingType"
+  ]
+}

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToAuthorityMapper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/MarcToAuthorityMapper.java
@@ -39,7 +39,7 @@ public class MarcToAuthorityMapper implements RecordMapper<Authority> {
     return MARC_FORMAT;
   }
 
-  private void linkSourceFile(JsonObject parsedRecord, MappingParameters mappingParameters, Authority authority) {
+  protected void linkSourceFile(JsonObject parsedRecord, MappingParameters mappingParameters, Authority authority) {
     var sourceFiles = mappingParameters.getAuthoritySourceFiles();
     if (sourceFiles == null || sourceFiles.isEmpty()) {
       return;

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/MarkToAuthorityExtendedMapper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/MarkToAuthorityExtendedMapper.java
@@ -1,0 +1,26 @@
+package org.folio.processing.mapping.defaultmapper;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.Authority;
+import org.folio.AuthorityExtended;
+import org.folio.processing.mapping.defaultmapper.processor.Processor;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+
+public class MarkToAuthorityExtendedMapper extends MarcToAuthorityMapper {
+
+  private static final String MARC_FORMAT = "MARC_AUTHORITY_EXTENDED";
+
+  @Override
+  public String getMapperFormat() {
+    return MARC_FORMAT;
+  }
+
+  @Override
+  public Authority mapRecord(JsonObject parsedRecord, MappingParameters mappingParameters, JsonObject mappingRules) {
+    var authority = new Processor<AuthorityExtended>().process(parsedRecord, mappingParameters, mappingRules,
+      AuthorityExtended.class);
+    linkSourceFile(parsedRecord, mappingParameters, authority);
+    return authority;
+  }
+}
+

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/RecordMapperBuilder.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/RecordMapperBuilder.java
@@ -8,8 +8,8 @@ import java.util.List;
 public final class RecordMapperBuilder {
 
   @SuppressWarnings("rawtypes")
-  private static final List<RecordMapper> mappers = List.of(new MarcToInstanceMapper(), new MarcToHoldingsMapper(), new MarcToAuthorityMapper());
-
+  private static final List<RecordMapper> mappers = List.of(new MarcToInstanceMapper(), new MarcToHoldingsMapper(),
+    new MarcToAuthorityMapper(), new MarkToAuthorityExtendedMapper());
   private RecordMapperBuilder() {
   }
 

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/LoaderHelper.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
+import org.folio.AuthorityExtended;
 
 public class LoaderHelper {
 
@@ -20,7 +21,7 @@ public class LoaderHelper {
     for (int i = 0; i < path.length; i++) {
       Field field;
       try {
-        field = object.getClass().getDeclaredField(path[i]);
+        field = getField(object.getClass(), path[i]);
       } catch (NoSuchFieldException e) {
         return false;
       }
@@ -59,5 +60,17 @@ public class LoaderHelper {
     } catch (IOException e) {
       LOGGER.error(e.getMessage(), e);
     }
+  }
+
+  public static Field getField(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+    if (clazz == AuthorityExtended.class) {
+      try {
+        return clazz.getDeclaredField(fieldName);
+      }
+      catch (NoSuchFieldException e) {
+        return clazz.getSuperclass().getDeclaredField(fieldName);
+      }
+    }
+    return clazz.getDeclaredField(fieldName);
   }
 }

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -53,6 +53,7 @@ public class Processor<T> {
   private static final String IND_2 = "ind2";
   private static final String WILDCARD_INDICATOR = "*";
   private static final String TARGET = "target";
+  private static final String DESCRIPTION = "description";
   private static final String SUBFIELD = "subfield";
   public static final String ALTERNATIVE_MAPPING = "alternativeMapping";
   private static final List<String> DEFAULT_SUBFIELDS = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i",
@@ -977,11 +978,11 @@ public class Processor<T> {
 
       Map<String, Object> headingRefMapping = new LinkedHashMap<>(existingMap);
       headingRefMapping.put(TARGET, target + ".headingRef");
-      headingRefMapping.put("description", existingMap.get(TARGET));
+      headingRefMapping.put(DESCRIPTION, existingMap.get(TARGET));
 
       Map<String, Object>  headingTypeMapping = new LinkedHashMap<>(existingMap);
       headingTypeMapping.put(TARGET, target + ".headingType");
-      headingTypeMapping.put("description", getHeadingType(existingMap.get(TARGET)));
+      headingTypeMapping.put(DESCRIPTION, getHeadingType(existingMap.get(TARGET)));
       headingTypeMapping.put("applyRulesOnConcatenatedData", true);
       JsonArray entityRules = JsonArray.of(new JsonObject(Map.of("conditions",
         JsonArray.of(JsonObject.of("type", "set_heading_type_by_name",

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -496,6 +496,15 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
     }
   },
 
+  SET_HEADING_TYPE_BY_NAME() {
+    private static final String NAME_PARAMETER = "name";
+
+    @Override
+    public String apply(RuleExecutionContext context) {
+      return context.getRuleParameter().getString(NAME_PARAMETER);
+    }
+  },
+
   SET_ALTERNATIVE_TITLE_TYPE_ID() {
     private static final String NAME_PARAMETER = "name";
 

--- a/src/test/java/org/folio/processing/mapping/AuthorityExtendedMappingTest.java
+++ b/src/test/java/org/folio/processing/mapping/AuthorityExtendedMappingTest.java
@@ -1,0 +1,54 @@
+package org.folio.processing.mapping;
+
+
+import io.vertx.core.json.JsonObject;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.folio.Authority;
+import org.folio.processing.TestUtil;
+import org.folio.processing.mapping.defaultmapper.RecordMapper;
+import org.folio.processing.mapping.defaultmapper.RecordMapperBuilder;
+import org.folio.processing.mapping.defaultmapper.processor.parameters.MappingParameters;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.marc4j.MarcJsonReader;
+import org.marc4j.MarcJsonWriter;
+import org.marc4j.marc.Record;
+
+@RunWith(JUnit4.class)
+public class AuthorityExtendedMappingTest {
+
+  private static final String MAPPED_AUTHORITY_RECORD_EXTENDED =
+    "src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json";
+  private static final String DEFAULT_MAPPING_RULES_PATH =
+    "src/test/resources/org/folio/processing/mapping/authority/authorityRules.json";
+  private static final String PARSED_AUTHORITY_RECORD_EXTENDED =
+    "src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json";
+
+  private final RecordMapper<Authority> mapper = RecordMapperBuilder.buildMapper("MARC_AUTHORITY_EXTENDED");
+
+  @Test
+  public void testMarcToAuthorityExtendedMapping() throws IOException {
+    JsonObject expectedMappedAuthority = new JsonObject(TestUtil.readFileFromPath(MAPPED_AUTHORITY_RECORD_EXTENDED));
+    JsonObject mappingRules = new JsonObject(TestUtil.readFileFromPath(DEFAULT_MAPPING_RULES_PATH));
+
+    Authority actualMappedAuthority = mapper
+      .mapRecord(getJsonMarcRecord(), new MappingParameters(), mappingRules);
+    Assert.assertEquals(expectedMappedAuthority.encode(), JsonObject.mapFrom(actualMappedAuthority).encode());
+  }
+
+  private JsonObject getJsonMarcRecord() throws IOException {
+    MarcJsonReader reader = new MarcJsonReader(
+      new ByteArrayInputStream(
+        TestUtil.readFileFromPath(PARSED_AUTHORITY_RECORD_EXTENDED).getBytes(StandardCharsets.UTF_8)));
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    MarcJsonWriter writer = new MarcJsonWriter(os);
+    Record record = reader.next();
+    writer.write(record);
+    return new JsonObject(os.toString());
+  }
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
@@ -1,0 +1,82 @@
+{
+  "saftBroaderTerm": [
+    {
+      "headingRef": "Broader-earlier - 511",
+      "headingType": "meetingNameTitle"
+    }
+  ],
+  "saftNarrowerTerm": [
+    {
+      "headingRef": "Some narrower term - 511",
+      "headingType":  "meetingName"
+    }
+  ],
+  "saftEarlierHeading": [
+    {
+      "headingRef": "Broader-earlier - 511",
+      "headingType": "meetingNameTitle"
+    },
+    {
+      "headingRef": "Dugmore, C. W.",
+      "headingType": "topicalTerm"
+    },
+    {
+      "headingRef": "Earlier - 551",
+      "headingType": "geographicName"
+    }
+  ],
+  "saftLaterHeading": [
+    {
+      "headingRef": "Periodicals",
+      "headingType": "uniformTitle"
+    }
+  ],
+  "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
+  "sftPersonalName": [ ],
+  "saftPersonalName": [ ],
+  "personalNameTitle": "Eimermacher, Karl CtY MBTI CtY MBTI NIC CStRLIN NIC",
+  "sftPersonalNameTitle": [ "v. 25 cm." ],
+  "saftPersonalNameTitle": [ "Editor:   C. W. Dugmore." ],
+  "sftCorporateName": [],
+  "saftCorporateName": [ ],
+  "corporateNameTitle": "BR140 .J6",
+  "sftCorporateNameTitle": [ "Quarterly, 1970-" ],
+  "saftCorporateNameTitle": [ "Church history" ],
+  "sftMeetingName": [ ],
+  "saftMeetingName": [ "Some narrower term - 511" ],
+  "meetingNameTitle": "270.05",
+  "sftMeetingNameTitle": [ "Semiannual, 1950-69" ],
+  "saftMeetingNameTitle": [ "Church history","Broader-earlier - 511"],
+  "uniformTitle": "The Journal of ecclesiastical history",
+  "sftUniformTitle": [ "v. 1-   Apr. 1950-", "History," ],
+  "saftUniformTitle": [ "Periodicals" ],
+  "topicalTerm": "The Journal of ecclesiastical history.",
+  "sftTopicalTerm": [ "note$a note$5", "note$aa note$bb" ],
+  "saftTopicalTerm": [ "Dugmore, C. W." ],
+  "subjectHeadings": "a",
+  "geographicName": "London,",
+  "sftGeographicName": [ "note$a note$5" ],
+  "saftGeographicName": [ "callNumber2", "Earlier - 551" ],
+  "genreTerm": "32 East 57th St., New York, 10022",
+  "sftGenreTerm": [ "note$a note$i note$x note$z note$5", "Later-narrower - 455", "Earlier - 455"],
+  "saftGenreTerm": [ "linkText publicNote" ],
+  "identifiers": [
+    {
+      "value": "1000649",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "n   58020553",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "0022-0469",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    },
+    {
+      "value": "(CStRLIN)NYCX1604275S",
+      "identifierTypeId": "fe19bae4-da28-472b-be90-d442e2428ead"
+    }
+  ],
+  "notes": [ ]
+}

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
@@ -1,0 +1,616 @@
+{
+  "leader": "01012cz  a2200241n  4500",
+  "fields": [
+    {
+      "001": "1000649"
+    },
+    {
+      "005": "20171119085041.0"
+    },
+    {
+      "008": "201001 n acanaaabn           n aaa     d"
+    },
+    {
+      "010": {
+        "subfields": [
+          {
+            "a": "n   58020553 "
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "024": {
+        "subfields": [
+          {
+            "a": "0022-0469"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "035": {
+        "subfields": [
+          {
+            "a": "(CStRLIN)NYCX1604275S"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Eimermacher, Karl"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "CtY"
+          },
+          {
+            "d": "MBTI"
+          },
+          {
+            "d": "NIC"
+          },
+          {
+            "d": "CStRLIN"
+          },
+          {
+            "t": "NIC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "110": {
+        "subfields": [
+          {
+            "a": "BR140"
+          },
+          {
+            "t": ".J6"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "111": {
+        "subfields": [
+          {
+            "t": "270.05"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "130": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "150": {
+        "subfields": [
+          {
+            "a": "The Journal of ecclesiastical history."
+          }
+        ],
+        "ind1": "0",
+        "ind2": "4"
+      }
+    },
+    {
+      "151": {
+        "subfields": [
+          {
+            "a": "London,"
+          },
+          {
+            "b": "Cambridge University Press [etc.]"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "155": {
+        "subfields": [
+          {
+            "a": "32 East 57th St., New York, 10022"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "375": {
+        "subfields": [
+          {
+            "a": "male"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "377": {
+        "subfields": [
+          {
+            "a": "ger"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "400": {
+        "subfields": [
+          {
+            "a": "v."
+          },
+          {
+            "t": "25 cm."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "410": {
+        "subfields": [
+          {
+            "a": "Quarterly,"
+          },
+          {
+            "t": "1970-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "411": {
+        "subfields": [
+          {
+            "a": "Semiannual,"
+          },
+          {
+            "t": "1950-69"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "a": "v. 1-   Apr. 1950-"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "430": {
+        "subfields": [
+          {
+            "w": "g"
+          },
+          {
+            "a": "History,"
+          },
+          {
+            "b": "1950-"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "450": {
+        "subfields": [
+          {
+            "w": "a"
+          },
+          {
+            "a": "note$aa"
+          },
+          {
+            "b": "note$bb"
+          },
+          {
+            "3": "note$2"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "451": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "6": "note$6"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "a": "note$a"
+          },
+          {
+            "b": "note$b"
+          },
+          {
+            "c": "note$c"
+          },
+          {
+            "d": "note$d"
+          },
+          {
+            "e": "note$e"
+          },
+          {
+            "f": "note$f"
+          },
+          {
+            "h": "note$h"
+          },
+          {
+            "i": "note$i"
+          },
+          {
+            "j": "note$j"
+          },
+          {
+            "k": "note$k"
+          },
+          {
+            "l": "note$l"
+          },
+          {
+            "n": "note$n"
+          },
+          {
+            "o": "note$o"
+          },
+          {
+            "u": "note$u"
+          },
+          {
+            "x": "note$x"
+          },
+          {
+            "z": "note$z"
+          },
+          {
+            "2": "note$2"
+          },
+          {
+            "3": "note$3"
+          },
+          {
+            "5": "note$5"
+          },
+          {
+            "8": "note$8"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "w":  "bh"
+          },
+          {
+            "v": "Later-narrower - 455"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "455": {
+        "subfields": [
+          {
+            "w":  "a"
+          },
+          {
+            "i": "Earlier"
+          },
+          {
+            "x": "- 455"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "500": {
+        "subfields": [
+          {
+            "t": "Editor:   C. W. Dugmore."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "510": {
+        "subfields": [
+          {
+            "w": "e"
+          },
+          {
+            "t": "Church history"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "0"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "t": "Church history"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst00860740"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "w": "nga"
+          },
+          {
+            "t": "Broader-earlier"
+          },
+          {
+            "a": "- 511"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "530": {
+        "subfields": [
+          {
+            "w": "b"
+          },
+          {
+            "a": "Periodicals"
+          },
+          {
+            "2": "fast"
+          },
+          {
+            "0": "(OCoLC)fst01411641"
+          }
+        ],
+        "ind1": " ",
+        "ind2": "7"
+      }
+    },
+    {
+      "511": {
+        "subfields": [
+          {
+            "w": "h"
+          },
+          {
+            "a": "Some"
+          },
+          {
+            "q": "narrower"
+          },
+          {
+            "c": "term"
+          },
+          {
+            "d": "- 511"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "550": {
+        "subfields": [
+          {
+            "w": "a"
+          },
+          {
+            "a": "Dugmore, C. W."
+          },
+          {
+            "q": "(Clifford William),"
+          },
+          {
+            "e": "ed."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "k": "callNumberPrefix"
+          },
+          {
+            "h": "callNumber1"
+          },
+          {
+            "i": "callNumber2"
+          },
+          {
+            "m": "callNumberSuffix"
+          },
+          {
+            "t": "copyNumber"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "555": {
+        "subfields": [
+          {
+            "u": "uri"
+          },
+          {
+            "y": "linkText"
+          },
+          {
+            "3": "materialsSpecification"
+          },
+          {
+            "z": "publicNote"
+          }
+        ],
+        "ind1": "0",
+        "ind2": "3"
+      }
+    },
+    {
+      "551": {
+        "subfields": [
+          {
+            "w": "a"
+          },
+          {
+            "a": "Earlier"
+          },
+          {
+            "g": "- 551"
+          }
+        ],
+        "ind1": "0",
+        "ind2": " "
+      }
+    },
+    {
+      "999": {
+        "ind1": "f",
+        "ind2": "f",
+        "subfields": [
+          {
+            "i": "b90cb1bc-601f-45d7-b99e-b11efd281dcd"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
There is an extended Authority Mapping introduced to support advanced references classification in 4xx-5xx fields:

broader terms ($wg tag)
narrower terms ($wh tag)
earlier headings ($wa tag)
later headings ($wb tag)

## Approach
Including this functionality requires generating AuthorityExtended class and applying MarkToAuthorityExtendedMapper.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
