### PR TITLE
MODDICORE-430: Vert.x 4.5.11 fixing snappy-java vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <logger.version>2.0.6</logger.version>
     <jackson.version>2.14.2</jackson.version>
     <junit.version>4.13.2</junit.version>
-    <vertx.version>4.5.7</vertx.version>
+    <vertx.version>4.5.11</vertx.version>
     <wiremock.version>3.0.1</wiremock.version>
     <raml-module-builder.version>35.3.0</raml-module-builder.version>
     <sonar.exclusions>org.folio.processing.mapping.defaultmapper.**</sonar.exclusions>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDICORE-430

## Purpose
data-import-processing-core comes with snappy-java 1.1.10.0 that has four security vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2023-43642
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454

How can this be fixed?

## Approach
Upgrade Vertx from 4.5.7 to 4.5.11.

This indirectly upgrades snappy-java from 1.1.10.0 to 1.1.10.5 fixing the vulnerabilities.

#### TODOS and Open Questions
- [x] Check logging.

## Learning
RMB 35.3.0 comes with Vert.x 4.5.10 that has the fixed snappy-java version. For an unknown reason data-import-processing-core has used Vert.x to 4.5.7 since it upgraded to RMB 35.3.0: https://folio-org.atlassian.net/browse/MODDICORE-425 = https://github.com/folio-org/data-import-processing-core/pull/369/files

When upgrading RMB upgrade Vert.x to a least the version used in that RMB version.