### PR TITLE
MODDICORE-436: Apply "--" subFieldDelimiter to AuthorityExtended fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,5 +153,6 @@ There is an extended Authority Mapping introduced to support advanced references
 * earlier headings (`$wa` tag)
 * later headings (`$wb` tag)
 * saft*Trunc for every saft* field with "i" and numeric subfields excluded
+* "subFieldDelimiter" to replace space by "--" before subfields $x,$y,$z,$v
 
 To support this functionality `AuthorityExtended` is used together with `MarkToAuthorityExtendedMapper`.

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -65,6 +65,7 @@ public class Processor<T> {
   public static final String ALTERNATIVE_MAPPING = "alternativeMapping";
   private static final String FIELDS_WITH_TRUNCATED_MAPPING_POSTFIX = "Trunc";
   private static final String SAFT_FIELDS_PREFIX = "saft";
+  public static final String DELIMITER_SUBFIELDS = "subfields";
 
   private JsonObject mappingRules;
 
@@ -478,7 +479,7 @@ public class Processor<T> {
       for (int i = 0; i < delimiters.size(); i++) {
         JsonObject job = delimiters.getJsonObject(i);
         String delimiter = job.getString(VALUE);
-        JsonArray subFieldswithDel = job.getJsonArray("subfields");
+        JsonArray subFieldswithDel = job.getJsonArray(DELIMITER_SUBFIELDS);
         StringBuilder subFieldsStringBuilder = new StringBuilder();
         buffers2concat.add(subFieldsStringBuilder);
         if (subFieldswithDel.size() == 0) {
@@ -981,16 +982,17 @@ public class Processor<T> {
     final List<String> doubleDashedSubfields = List.of("x", "y", "z", "v");
     List<LinkedHashMap<String, Object>> mappingList = mappingArray.getList();
     mappingList.forEach(mapping -> {
-      List<String> subfields = (List) mapping.get("subfield");
+      List<String> subfields = (List) mapping.get(SUBFIELD);
       if (subfields == null || subfields.stream().noneMatch(doubleDashedSubfields::contains)) {
         return;
       }
       List<LinkedHashMap<String, Object>> subFieldDelimiterList = new ArrayList<>();
-      LinkedHashMap<String, Object> spaceDelimiter = new LinkedHashMap<>(Map.of(VALUE, " ", "subfields",
+      LinkedHashMap<String, Object> spaceDelimiter = new LinkedHashMap<>(Map.of(VALUE, " ", DELIMITER_SUBFIELDS,
         subfields.stream().filter(s -> !doubleDashedSubfields.contains(s)).toList()));
       subFieldDelimiterList.add(spaceDelimiter);
-      subFieldDelimiterList.add(new LinkedHashMap<>(Map.of(VALUE, "--", "subfields", doubleDashedSubfields)));
-      subFieldDelimiterList.add(new LinkedHashMap<>(Map.of(VALUE, "--", "subfields", List.of())));
+      subFieldDelimiterList.add(new LinkedHashMap<>(Map.of(VALUE, "--", DELIMITER_SUBFIELDS,
+        doubleDashedSubfields)));
+      subFieldDelimiterList.add(new LinkedHashMap<>(Map.of(VALUE, "--", DELIMITER_SUBFIELDS, List.of())));
       mapping.put("subFieldDelimiter", subFieldDelimiterList);
       }
     );

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
@@ -17,7 +17,7 @@
       "headingType": "meetingNameTitleTrunc"
     },
     {
-      "headingRef": "Dugmore, C. W.",
+      "headingRef": "linkText",
       "headingType": "topicalTermTrunc"
     },
     {
@@ -27,7 +27,7 @@
   ],
   "saftLaterHeading": [
     {
-      "headingRef": "Periodicals",
+      "headingRef": "Periodicals--linkText",
       "headingType": "uniformTitleTrunc"
     }
   ],
@@ -51,17 +51,17 @@
     "Broader-earlier - 511"
   ],
   "saftUniformTitleTrunc": [
-    "Periodicals"
+    "Periodicals--linkText"
   ],
   "saftTopicalTermTrunc": [
-    "Dugmore, C. W."
+    "linkText"
   ],
   "saftGeographicNameTrunc": [
     "callNumber",
     "Earlier - 551"
   ],
   "saftGenreTermTrunc": [
-    "linkText publicNote"
+    "linkText--publicNote"
   ],
   "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
   "sftPersonalName": [
@@ -104,13 +104,13 @@
     "Church history",
     "Broader-earlier - 511"
   ],
-  "uniformTitle": "The Journal of ecclesiastical history",
+  "uniformTitle": "The Journal of ecclesiastical history--linkText",
   "sftUniformTitle": [
     "v. 1-   Apr. 1950-",
     "History,"
   ],
   "saftUniformTitle": [
-    "Periodicals"
+    "Periodicals--linkText"
   ],
   "topicalTerm": "The Journal of ecclesiastical history.",
   "sftTopicalTerm": [
@@ -118,7 +118,7 @@
     "note$aa note$bb"
   ],
   "saftTopicalTerm": [
-    "Dugmore, C. W."
+    "linkText"
   ],
   "subjectHeadings": "a",
   "geographicName": "London,",
@@ -131,12 +131,12 @@
   ],
   "genreTerm": "32 East 57th St., New York, 10022",
   "sftGenreTerm": [
-    "note$a note$i note$x note$z note$5",
+    "note$a note$i note$5--note$x--note$z",
     "Later-narrower - 455",
-    "Earlier - 455"
+    "Earlier--- 455"
   ],
   "saftGenreTerm": [
-    "Narrator: linkText publicNote"
+    "Narrator:--linkText--publicNote"
   ],
   "identifiers": [
     {

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
@@ -105,6 +105,9 @@
         "subfields": [
           {
             "a": "The Journal of ecclesiastical history"
+          },
+          {
+            "v": "linkText"
           }
         ],
         "ind1": "0",
@@ -438,6 +441,9 @@
           },
           {
             "t": "Church history"
+          },
+          {
+            "x": "linkText"
           }
         ],
         "ind1": " ",
@@ -492,6 +498,9 @@
           },
           {
             "0": "(OCoLC)fst01411641"
+          },
+          {
+            "x": "linkText"
           }
         ],
         "ind1": " ",
@@ -528,13 +537,16 @@
             "w": "a"
           },
           {
-            "a": "Dugmore, C. W."
+            "k": "Dugmore, C. W."
           },
           {
             "q": "(Clifford William),"
           },
           {
             "e": "ed."
+          },
+          {
+            "z": "linkText"
           }
         ],
         "ind1": "1",


### PR DESCRIPTION
[MODDICORE-436](https://folio-org.atlassian.net/browse/MODDICORE-436)
## Purpose
For ASA customer it is required to apply subFieldDelimiter “--” before tags “x”, “y”, “z”, “v” in 1xx, 4xx and 5xx fields.

## Approach
subFieldDelimiter "--" mapping is added programmatically for AuthorityExtended instances.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
