### PR TITLE
MODDICORE-426-436 authorities custom mapping Ramsons

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,5 +153,6 @@ There is an extended Authority Mapping introduced to support advanced references
 * earlier headings (`$wa` tag)
 * later headings (`$wb` tag)
 * saft*Trunc for every saft* field with "i" and numeric subfields excluded
+* "subFieldDelimiter" to replace space by "--" before subfields $x,$y,$z,$v
 
 To support this functionality `AuthorityExtended` is used together with `MarkToAuthorityExtendedMapper`.

--- a/README.md
+++ b/README.md
@@ -152,5 +152,6 @@ There is an extended Authority Mapping introduced to support advanced references
 * narrower terms (`$wh` tag)
 * earlier headings (`$wa` tag)
 * later headings (`$wb` tag)
+* saft*Trunc for every saft* field with "i" and numeric subfields excluded
 
 To support this functionality `AuthorityExtended` is used together with `MarkToAuthorityExtendedMapper`.

--- a/ramls/authorityExtended.json
+++ b/ramls/authorityExtended.json
@@ -33,6 +33,76 @@
       "items": {
         "$ref": "relatedHeading.json"
       }
+    },
+    "saftPersonalNameTrunc": {
+      "type": "array",
+      "description": "See also from tracing personal name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftPersonalNameTitleTrunc": {
+      "type": "array",
+      "description": "See also from tracing personal name title",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftCorporateNameTrunc": {
+      "type": "array",
+      "description": "See also from tracing corporate name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftCorporateNameTitleTrunc": {
+      "type": "array",
+      "description": "See also from tracing corporate name title",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftMeetingNameTrunc": {
+      "type": "array",
+      "description": "See also from tracing meeting name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftMeetingNameTitleTrunc": {
+      "type": "array",
+      "description": "See also from tracing meeting name title",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftUniformTitleTrunc": {
+      "type": "array",
+      "description": "See also from tracing uniform title",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftTopicalTermTrunc": {
+      "type": "array",
+      "description": "See also from tracing topical term",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGeographicNameTrunc": {
+      "type": "array",
+      "description": "See also from tracing geographic name",
+      "items": {
+        "type": "string"
+      }
+    },
+    "saftGenreTermTrunc": {
+      "type": "array",
+      "description": "See also from tracing genre/form term",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/Processor.java
@@ -63,8 +63,8 @@ public class Processor<T> {
   private static final Map<Class<?>, Map<String, Method>> METHOD_CACHE = new ConcurrentHashMap<>();
   private static final Map<Field, ParameterizedType> PARAM_TYPE_CACHE = new ConcurrentHashMap<>();
   public static final String ALTERNATIVE_MAPPING = "alternativeMapping";
-  private static final List<String> DEFAULT_SUBFIELDS = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i",
-    "j", "k", "l", "m", "n", "o", "p", "r", "q", "s", "t", "v", "x", "y", "z", "4", "5");
+  private static final String FIELDS_WITH_TRUNCATED_MAPPING_POSTFIX = "Trunc";
+  private static final String SAFT_FIELDS_PREFIX = "saft";
 
   private JsonObject mappingRules;
 
@@ -952,26 +952,63 @@ public class Processor<T> {
   /**
    * Extends regular entity mapping for 5xx field with one according to the following rules:
    * additionally to the regular mapping adds the mapping for targets:
+   *
    * saftBroaderTerm,  when the control subfield $w has "g" value
    * saftNarrowerTerm, when the control subfield $w has "h" value
    * saftEarlierHeading, when the control subfield $w has "a" value
    * saftLaterHeading, when the control subfield $w has "b" value.
+   *
+   * saft*Trunc for every saft* field with "i" and numeric subfields excluded
    */
   private JsonArray addExtraMappingsForAuthorities(final DataField dataField, final JsonArray regularMapping) {
     boolean is5XXField = dataField.getTag().startsWith("5");
-    if (!is5XXField || dataField.getSubfield('w') == null || regularMapping == null || regularMapping.isEmpty()) {
+    if (!is5XXField || regularMapping == null || regularMapping.isEmpty()) {
       return regularMapping;
     }
     final JsonArray extendedMapping = new JsonArray();
     List<String> targets = retrieveTargetsFromControlSubfield(dataField);
     List<LinkedHashMap<String, Object>> mappingList = regularMapping.getList();
-    targets.forEach(target -> extendedMapping.addAll(createAdditionalMappingsForTarget(target, mappingList)));
+    List<LinkedHashMap<String, Object>> truncatedMappingList = createTruncatedMappingList(mappingList);
+    targets.forEach(target ->  extendedMapping.addAll(createRelationsMappingForTarget(target, truncatedMappingList)));
     extendedMapping.addAll(regularMapping);
+    extendedMapping.addAll(new JsonArray(truncatedMappingList));
     return extendedMapping;
+  }
+
+  /**
+   * Creates a new mapping list from the original one
+   * where subfields "i" and numeric subfields are excluded
+   */
+  private List<LinkedHashMap<String, Object>> createTruncatedMappingList(
+    final List<LinkedHashMap<String, Object>> originalMappingList) {
+    List<LinkedHashMap<String, Object>> truncatedMappingList = new ArrayList<>();
+    originalMappingList.forEach(map -> {
+      LinkedHashMap<String, Object> truncatedMappingMap = new LinkedHashMap<>();
+      map.forEach((key, value) -> {
+        if (key.equals(TARGET)) {
+          truncatedMappingMap.put(TARGET, value + FIELDS_WITH_TRUNCATED_MAPPING_POSTFIX);
+          return;
+        }
+        if (key.equals(SUBFIELD)) {
+          List<String> subfieldList = (List) value;
+          List<String> truncatedSubfieldList = subfieldList.stream()
+            .filter(s -> !s.matches("[0-9i]"))
+            .toList();
+          truncatedMappingMap.put(SUBFIELD, truncatedSubfieldList);
+          return;
+        }
+        truncatedMappingMap.put(key, value);
+      });
+      truncatedMappingList.add(truncatedMappingMap);
+    });
+    return truncatedMappingList;
   }
 
   private List<String> retrieveTargetsFromControlSubfield(DataField dataField) {
     List<String> targets = new ArrayList<>();
+    if (dataField.getSubfield('w') == null) {
+      return targets;
+    }
     String subfieldData = dataField.getSubfield('w').getData();
     if (subfieldData.contains("g")) {
       targets.add("saftBroaderTerm");
@@ -1050,7 +1087,7 @@ public class Processor<T> {
    *     ]
    *   }
    */
-  private JsonArray createAdditionalMappingsForTarget(String target, List<LinkedHashMap<String, Object>> existingMappingList) {
+  private JsonArray createRelationsMappingForTarget(String target, List<LinkedHashMap<String, Object>> existingMappingList) {
     JsonArray additionalMappings = new JsonArray();
     existingMappingList.forEach(existingMap -> {
 
@@ -1075,7 +1112,7 @@ public class Processor<T> {
   }
 
   private static Object getHeadingType(Object headingField) {
-    String headingRType = headingField.toString().replace("saft", "");
+    String headingRType = headingField.toString().replace(SAFT_FIELDS_PREFIX, "");
     return Character.toLowerCase(headingRType.charAt(0)) + headingRType.substring(1);
   }
 }

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
@@ -17,7 +17,7 @@
       "headingType": "meetingNameTitleTrunc"
     },
     {
-      "headingRef": "Dugmore, C. W.",
+      "headingRef": "linkText",
       "headingType": "topicalTermTrunc"
     },
     {
@@ -27,7 +27,7 @@
   ],
   "saftLaterHeading": [
     {
-      "headingRef": "Periodicals",
+      "headingRef": "Periodicals--linkText",
       "headingType": "uniformTitleTrunc"
     }
   ],
@@ -51,17 +51,17 @@
     "Broader-earlier - 511"
   ],
   "saftUniformTitleTrunc": [
-    "Periodicals"
+    "Periodicals--linkText"
   ],
   "saftTopicalTermTrunc": [
-    "Dugmore, C. W."
+    "linkText"
   ],
   "saftGeographicNameTrunc": [
     "callNumber",
     "Earlier - 551"
   ],
   "saftGenreTermTrunc": [
-    "linkText publicNote"
+    "linkText--publicNote"
   ],
   "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
   "sftPersonalName": [
@@ -104,13 +104,13 @@
     "Church history",
     "Broader-earlier - 511"
   ],
-  "uniformTitle": "The Journal of ecclesiastical history",
+  "uniformTitle": "The Journal of ecclesiastical history--linkText",
   "sftUniformTitle": [
     "v. 1-   Apr. 1950-",
     "History,"
   ],
   "saftUniformTitle": [
-    "Periodicals"
+    "Periodicals--linkText"
   ],
   "topicalTerm": "The Journal of ecclesiastical history.",
   "sftTopicalTerm": [
@@ -118,7 +118,7 @@
     "note$aa note$bb"
   ],
   "saftTopicalTerm": [
-    "Dugmore, C. W."
+    "linkText"
   ],
   "subjectHeadings": "a",
   "geographicName": "London,",
@@ -131,12 +131,12 @@
   ],
   "genreTerm": "32 East 57th St., New York, 10022",
   "sftGenreTerm": [
-    "note$a note$i note$x note$z note$5",
+    "note$a note$i note$5--note$x--note$z",
     "Later-narrower - 455",
-    "Earlier - 455"
+    "Earlier--- 455"
   ],
   "saftGenreTerm": [
-    "Narrator: linkText publicNote"
+    "Narrator:--linkText--publicNote"
   ],
   "identifiers": [
     {

--- a/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/mappedRecordExtended.json
@@ -2,64 +2,142 @@
   "saftBroaderTerm": [
     {
       "headingRef": "Broader-earlier - 511",
-      "headingType": "meetingNameTitle"
+      "headingType": "meetingNameTitleTrunc"
     }
   ],
   "saftNarrowerTerm": [
     {
       "headingRef": "Some narrower term - 511",
-      "headingType":  "meetingName"
+      "headingType": "meetingNameTrunc"
     }
   ],
   "saftEarlierHeading": [
     {
       "headingRef": "Broader-earlier - 511",
-      "headingType": "meetingNameTitle"
+      "headingType": "meetingNameTitleTrunc"
     },
     {
       "headingRef": "Dugmore, C. W.",
-      "headingType": "topicalTerm"
+      "headingType": "topicalTermTrunc"
     },
     {
       "headingRef": "Earlier - 551",
-      "headingType": "geographicName"
+      "headingType": "geographicNameTrunc"
     }
   ],
   "saftLaterHeading": [
     {
       "headingRef": "Periodicals",
-      "headingType": "uniformTitle"
+      "headingType": "uniformTitleTrunc"
     }
   ],
+  "saftPersonalNameTrunc": [
+
+  ],
+  "saftPersonalNameTitleTrunc": [
+    "Editor:   C. W. Dugmore."
+  ],
+  "saftCorporateNameTrunc": [
+
+  ],
+  "saftCorporateNameTitleTrunc": [
+    "Church history"
+  ],
+  "saftMeetingNameTrunc": [
+    "Some narrower term - 511"
+  ],
+  "saftMeetingNameTitleTrunc": [
+    "Church history",
+    "Broader-earlier - 511"
+  ],
+  "saftUniformTitleTrunc": [
+    "Periodicals"
+  ],
+  "saftTopicalTermTrunc": [
+    "Dugmore, C. W."
+  ],
+  "saftGeographicNameTrunc": [
+    "callNumber",
+    "Earlier - 551"
+  ],
+  "saftGenreTermTrunc": [
+    "linkText publicNote"
+  ],
   "id": "b90cb1bc-601f-45d7-b99e-b11efd281dcd",
-  "sftPersonalName": [ ],
-  "saftPersonalName": [ ],
+  "sftPersonalName": [
+
+  ],
+  "saftPersonalName": [
+
+  ],
   "personalNameTitle": "Eimermacher, Karl CtY MBTI CtY MBTI NIC CStRLIN NIC",
-  "sftPersonalNameTitle": [ "v. 25 cm." ],
-  "saftPersonalNameTitle": [ "Editor:   C. W. Dugmore." ],
-  "sftCorporateName": [],
-  "saftCorporateName": [ ],
+  "sftPersonalNameTitle": [
+    "v. 25 cm."
+  ],
+  "saftPersonalNameTitle": [
+    "Editor:   C. W. Dugmore."
+  ],
+  "sftCorporateName": [
+
+  ],
+  "saftCorporateName": [
+
+  ],
   "corporateNameTitle": "BR140 .J6",
-  "sftCorporateNameTitle": [ "Quarterly, 1970-" ],
-  "saftCorporateNameTitle": [ "Church history" ],
-  "sftMeetingName": [ ],
-  "saftMeetingName": [ "Some narrower term - 511" ],
+  "sftCorporateNameTitle": [
+    "Quarterly, 1970-"
+  ],
+  "saftCorporateNameTitle": [
+    "Church history"
+  ],
+  "sftMeetingName": [
+
+  ],
+  "saftMeetingName": [
+    "Some narrower term - 511"
+  ],
   "meetingNameTitle": "270.05",
-  "sftMeetingNameTitle": [ "Semiannual, 1950-69" ],
-  "saftMeetingNameTitle": [ "Church history","Broader-earlier - 511"],
+  "sftMeetingNameTitle": [
+    "Semiannual, 1950-69"
+  ],
+  "saftMeetingNameTitle": [
+    "Church history",
+    "Broader-earlier - 511"
+  ],
   "uniformTitle": "The Journal of ecclesiastical history",
-  "sftUniformTitle": [ "v. 1-   Apr. 1950-", "History," ],
-  "saftUniformTitle": [ "Periodicals" ],
+  "sftUniformTitle": [
+    "v. 1-   Apr. 1950-",
+    "History,"
+  ],
+  "saftUniformTitle": [
+    "Periodicals"
+  ],
   "topicalTerm": "The Journal of ecclesiastical history.",
-  "sftTopicalTerm": [ "note$a note$5", "note$aa note$bb" ],
-  "saftTopicalTerm": [ "Dugmore, C. W." ],
+  "sftTopicalTerm": [
+    "note$a note$5",
+    "note$aa note$bb"
+  ],
+  "saftTopicalTerm": [
+    "Dugmore, C. W."
+  ],
   "subjectHeadings": "a",
   "geographicName": "London,",
-  "sftGeographicName": [ "note$a note$5" ],
-  "saftGeographicName": [ "callNumber2", "Earlier - 551" ],
+  "sftGeographicName": [
+    "note$a note$5"
+  ],
+  "saftGeographicName": [
+    "callNumber callNumber2",
+    "Earlier - 551 Successor: https://some/url"
+  ],
   "genreTerm": "32 East 57th St., New York, 10022",
-  "sftGenreTerm": [ "note$a note$i note$x note$z note$5", "Later-narrower - 455", "Earlier - 455"],
-  "saftGenreTerm": [ "linkText publicNote" ],
+  "sftGenreTerm": [
+    "note$a note$i note$x note$z note$5",
+    "Later-narrower - 455",
+    "Earlier - 455"
+  ],
+  "saftGenreTerm": [
+    "Narrator: linkText publicNote"
+  ],
   "identifiers": [
     {
       "value": "1000649",

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
@@ -105,6 +105,9 @@
         "subfields": [
           {
             "a": "The Journal of ecclesiastical history"
+          },
+          {
+            "v": "linkText"
           }
         ],
         "ind1": "0",
@@ -438,6 +441,9 @@
           },
           {
             "t": "Church history"
+          },
+          {
+            "x": "linkText"
           }
         ],
         "ind1": " ",
@@ -492,6 +498,9 @@
           },
           {
             "0": "(OCoLC)fst01411641"
+          },
+          {
+            "x": "linkText"
           }
         ],
         "ind1": " ",
@@ -528,13 +537,16 @@
             "w": "a"
           },
           {
-            "a": "Dugmore, C. W."
+            "k": "Dugmore, C. W."
           },
           {
             "q": "(Clifford William),"
           },
           {
             "e": "ed."
+          },
+          {
+            "z": "linkText"
           }
         ],
         "ind1": "1",

--- a/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
+++ b/src/test/resources/org/folio/processing/mapping/authority/parsedRecordExtended.json
@@ -545,6 +545,9 @@
       "551": {
         "subfields": [
           {
+            "a": "callNumber"
+          },
+          {
             "k": "callNumberPrefix"
           },
           {
@@ -568,6 +571,9 @@
       "555": {
         "subfields": [
           {
+            "i": "Narrator:"
+          },
+          {
             "u": "uri"
           },
           {
@@ -578,6 +584,9 @@
           },
           {
             "z": "publicNote"
+          },
+          {
+            "0": "http://some/url"
           }
         ],
         "ind1": "0",
@@ -595,6 +604,12 @@
           },
           {
             "g": "- 551"
+          },
+          {
+            "i": "Successor:"
+          },
+          {
+            "4": "https://some/url"
           }
         ],
         "ind1": "0",


### PR DESCRIPTION
[MODDICORE-426](https://folio-org.atlassian.net/browse/MODDICORE-426)
[MODDICORE-436](https://folio-org.atlassian.net/browse/MODDICORE-436)

## Purpose
MODDICORE-426:
For ASA customer it is required to exclude subfields “i” and numeric subfields from the mapping for 5xx fields in Authority.
Example:
$w r $i Successor: $a Sri Lanka $4 http://rdaregistry.info/Elements/u/P60686 $0 (DLC)n 80061039 $0 http://id.loc.gov/authorities/names/n80061039 $1 http://id.loc.gov/rwo/agents/n80061039
should be transformed to Sri Lanka, not to Successor: Sri Lanka

MODDICORE-436:
For ASA customer it is required to apply subFieldDelimiter “--” before tags “x”, “y”, “z”, “v” in 1xx, 4xx and 5xx fields.

## Approach
_How does this change fulfill the purpose?_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [ ] Check logging.
## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
