### PR TITLE
MODINVSTOR-1342: Add "deleted" field to Instance schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 202X-XX-XX 4.4.0-SNAPSHOT
 * [MODDICORE-433](https://folio-org.atlassian.net/browse/MODDICORE-433) Add userId to event header and allow to send events with null token
 * [MODDICORE-432](https://folio-org.atlassian.net/browse/MODDICORE-432) Vendor details are empty with code that contains brackets during order creation
+* [MODINVSTOR-1342](https://folio-org.atlassian.net/browse/MODINVSTOR-1342) Add "deleted" field to Instance schema
 
 ## 2024-10-28 v4.3.0
 * [MODDICORE-388](https://folio-org.atlassian.net/browse/MODDICORE-388) Allow to map vendor details with code that contains brackets during order creation

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -406,7 +406,8 @@
     },
     "deleted": {
       "type": "boolean",
-      "description": "Indicates whether the record was marked for deletion"
+      "description": "Indicates whether the record was marked for deletion",
+      "default": false
     },
     "statisticalCodeIds": {
       "type": "array",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -406,8 +406,7 @@
     },
     "deleted": {
       "type": "boolean",
-      "description": "Indicates whether the record was marked for deletion",
-      "default": false
+      "description": "Indicates whether the record was marked for deletion"
     },
     "statisticalCodeIds": {
       "type": "array",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -404,6 +404,10 @@
       "type": "boolean",
       "description": "Records the fact that the record should not be displayed in a discovery system"
     },
+    "deleted": {
+      "type": "boolean",
+      "description": "Indicates whether the record was marked for deletion"
+    },
     "statisticalCodeIds": {
       "type": "array",
       "description": "List of statistical code IDs",


### PR DESCRIPTION
## Purpose
Add boolean “deleted” field to Instance with default value=false

#### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.
- [x] Check logging.

