### PR TITLE
MODDATAIMP-1189: Fix update of MARC bibliographic fails with "NullPointerException"

### DIFF
--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -41,11 +41,11 @@ import static org.folio.rest.jaxrs.model.ProfileType.MATCH_PROFILE;
  */
 public final class EventManager {
 
+  private static final Logger LOGGER = LogManager.getLogger(EventManager.class);
+
   public static final String POST_PROCESSING_INDICATOR = "POST_PROCESSING";
   public static final String POST_PROCESSING_RESULT_EVENT_KEY = "POST_PROCESSING_RESULT_EVENT";
   public static final String OL_ACCUMULATIVE_RESULTS = "OL_ACCUMULATIVE_RESULTS";
-
-  private static final Logger LOGGER = LogManager.getLogger(EventManager.class);
 
   private static final EventProcessor eventProcessor = new EventProcessorImpl();
   private static final List<EventPublisher> eventPublisher = new ArrayList<>(Arrays.<EventPublisher>asList(new RestEventPublisher()));
@@ -67,6 +67,7 @@ public final class EventManager {
    * @return future with event payload after handling
    */
   public static CompletableFuture<DataImportEventPayload> handleEvent(DataImportEventPayload eventPayload, ProfileSnapshotWrapper jobProfileSnapshot) {
+    LOGGER.trace("handleEvent:: Event type: {}, event payload: {}", eventPayload.getEventType(), eventPayload);
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
     try {
       setCurrentNodeIfRoot(eventPayload, jobProfileSnapshot);
@@ -89,21 +90,24 @@ public final class EventManager {
   }
 
   private static void setCurrentNodeIfRoot(DataImportEventPayload eventPayload, ProfileSnapshotWrapper jobProfileSnapshot) {
+    LOGGER.trace("setCurrentNodeIfRoot:: Event type: {}, event payload: {}", eventPayload.getEventType(), eventPayload);
     if (eventPayload.getCurrentNode() == null || eventPayload.getCurrentNode().getContentType() == JOB_PROFILE) {
       List<ProfileSnapshotWrapper> jobProfileChildren = jobProfileSnapshot.getChildSnapshotWrappers();
       if (isNotEmpty(jobProfileChildren)) {
-        eventPayload.setCurrentNode(jobProfileChildren.get(0));
+        eventPayload.setCurrentNode(jobProfileChildren.getFirst());
       }
       eventPayload.setCurrentNodePath(new ArrayList<>(Collections.singletonList(jobProfileSnapshot.getId())));
     }
   }
 
   private static CompletableFuture<Boolean> publishEventIfNecessary(DataImportEventPayload eventPayload, ProfileSnapshotWrapper jobProfileSnapshot, Throwable processThrowable) {
+    LOGGER.trace("publishEventIfNecessary:: Event type: {}, event payload: {}", eventPayload.getEventType(), eventPayload, processThrowable);
     if (processThrowable instanceof EventHandlerNotFoundException ||
       (Objects.nonNull(processThrowable) && processThrowable.getCause() instanceof DuplicateEventException)) {
       return CompletableFuture.completedFuture(false);
     }
-    return eventPublisher.get(0).publish(prepareEventPayload(eventPayload, jobProfileSnapshot, processThrowable))
+    LOGGER.trace("publishEventIfNecessary:: eventPublisher = {}", eventPublisher.getFirst().getClass().getSimpleName());
+    return eventPublisher.getFirst().publish(prepareEventPayload(eventPayload, jobProfileSnapshot, processThrowable))
       .thenApply(sentEvent -> true);
   }
 
@@ -167,7 +171,7 @@ public final class EventManager {
     }
     if (currentNode.getContentType() == ACTION_PROFILE) {
       if (isNotEmpty(currentNode.getChildSnapshotWrappers())) {
-        return Optional.of(currentNode.getChildSnapshotWrappers().get(0));
+        return Optional.of(currentNode.getChildSnapshotWrappers().getFirst());
       } else {
         return findParent(currentNode.getId(), jobProfileSnapshot)
           .flatMap(actionParent -> getNextChildProfile(currentNode, actionParent));
@@ -212,6 +216,7 @@ public final class EventManager {
    * @return true handlers is registered
    */
   public static <T extends EventHandler> boolean registerEventHandler(T eventHandler) {
+    LOGGER.trace("registerEventHandler:: Registering event handler: {}", eventHandler.getClass());
     return eventProcessor.getEventHandlers().add(eventHandler);
   }
 
@@ -222,6 +227,7 @@ public final class EventManager {
    * @param vertx       - vertx instance
    */
   public static void registerKafkaEventPublisher(KafkaConfig kafkaConfig, Vertx vertx, int maxDistributionNum) {
+    LOGGER.trace("registerKafkaEventPublisher:: Registering kafka event publisher");
     eventPublisher.forEach(p -> {
       LOGGER.info("registerKafkaEventPublisher {}", p.toString());
       if(p instanceof KafkaEventPublisher publisher) {
@@ -240,6 +246,7 @@ public final class EventManager {
    * Performs registration for rest event publisher in publishers list
    */
   public static void registerRestEventPublisher() {
+    LOGGER.trace("registerRestEventPublisher:: Registering rest event publisher");
     eventPublisher.clear();
     eventPublisher.add(new RestEventPublisher());
   }
@@ -248,6 +255,7 @@ public final class EventManager {
    * Clears the registry of event handlers.
    */
   public static void clearEventHandlers() {
+    LOGGER.trace("clearEventHandlers:: Clearing event publisher");
     eventProcessor.getEventHandlers().clear();
   }
 }

--- a/src/main/java/org/folio/processing/events/EventManager.java
+++ b/src/main/java/org/folio/processing/events/EventManager.java
@@ -255,7 +255,7 @@ public final class EventManager {
    * Clears the registry of event handlers.
    */
   public static void clearEventHandlers() {
-    LOGGER.trace("clearEventHandlers:: Clearing event publisher");
+    LOGGER.trace("clearEventHandlers:: Clearing event handlers");
     eventProcessor.getEventHandlers().clear();
   }
 }

--- a/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
+++ b/src/main/java/org/folio/processing/events/services/processor/EventProcessorImpl.java
@@ -25,6 +25,7 @@ public class EventProcessorImpl implements EventProcessor {
 
   @Override
   public CompletableFuture<DataImportEventPayload> process(DataImportEventPayload eventPayload) {
+    LOG.debug("process:: Processing event payload {}", eventPayload);
     CompletableFuture<DataImportEventPayload> future = new CompletableFuture<>();
     try {
       Optional<EventHandler> optionalEventHandler = eventHandlers.stream()
@@ -40,6 +41,7 @@ public class EventProcessorImpl implements EventProcessor {
           .whenComplete((payload, throwable) -> {
             logEventProcessingTime(eventType, startTime, eventPayload);
             if (throwable != null) {
+              LOG.warn("process:: Failed to process event payload", throwable);
               future.completeExceptionally(throwable);
             } else {
               future.complete(payload);
@@ -86,7 +88,7 @@ public class EventProcessorImpl implements EventProcessor {
 
   private String getLastEvent(DataImportEventPayload eventPayload) {
     final var eventsChain = eventPayload.getEventsChain();
-    return eventsChain.get(eventsChain.size() - 1);
+    return eventsChain.getLast();
   }
 
   private DataImportEventPayload updatePayloadIfNeeded(DataImportEventPayload dataImportEventPayload) {

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -924,8 +924,7 @@ public class MarcRecordModifier {
   private boolean matchesData(MarcFieldProtectionSetting setting, DataField field) {
     LOGGER.trace("matchesData:: field={} | setting: subfield={}, data={}", field.getTag(), setting.getSubfield(), setting.getData());
     if (setting.getSubfield().charAt(0) == ANY_CHAR) {
-      return setting.getData().equals(ANY_STRING) ||
-        field.getSubfields().stream().anyMatch(subfield -> dataMatches(setting, subfield));
+      return field.getSubfields().stream().anyMatch(subfield -> dataMatches(setting, subfield));
     } else {
       return Optional.ofNullable(field.getSubfield(setting.getSubfield().charAt(0)))
         .map(subfield -> dataMatches(setting, subfield))

--- a/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
+++ b/src/main/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifier.java
@@ -17,7 +17,11 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 

--- a/src/test/java/org/folio/processing/events/AbstractRestTest.java
+++ b/src/test/java/org/folio/processing/events/AbstractRestTest.java
@@ -3,6 +3,8 @@ package org.folio.processing.events;
 import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.Rule;
 
 import java.io.IOException;
@@ -10,6 +12,9 @@ import java.net.ServerSocket;
 import java.util.concurrent.ThreadLocalRandom;
 
 public abstract class AbstractRestTest {
+
+  private static final Logger LOGGER = LogManager.getLogger(AbstractRestTest.class);
+
   protected final String TENANT_ID = "diku";
   protected final String TOKEN = "token";
   private int PORT = nextFreePort();
@@ -22,6 +27,8 @@ public abstract class AbstractRestTest {
       .notifier(new Slf4jNotifier(true)));
 
   public static int nextFreePort() {
+    LOGGER.trace("nextFreePort:: creating random port");
+
     int maxTries = 10000;
     int port = ThreadLocalRandom.current().nextInt(49152 , 65535);
     while (true) {
@@ -38,6 +45,7 @@ public abstract class AbstractRestTest {
   }
 
   public static boolean isLocalPortFree(int port) {
+    LOGGER.trace("isLocalPortFree:: checking if port {} is free", port);
     try {
       new ServerSocket(port).close();
       return true;

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
@@ -2034,6 +2034,82 @@ public class MarcRecordModifierTest {
   }
 
   @Test
+  public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsNotProtectedAndIncomingFieldIsNotSameWithMultipleSubfieldProtectionSettings() {
+    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00152nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+
+    List<MarcFieldProtectionSetting> protectionSettings = List.of(
+      new MarcFieldProtectionSetting()
+        .withField("655")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfield("*")
+        .withData("notfast"));
+
+    MappingParameters mappingParameters = new MappingParameters()
+      .withMarcFieldProtectionSettings(protectionSettings);
+    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
+  }
+
+  @Test
+  public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsProtectedAndSomeIncomingFieldIsSameWithMatchesMultipleSubfieldProtectionSettings() {
+    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00200nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+
+    List<MarcFieldProtectionSetting> protectionSettings = List.of(
+      new MarcFieldProtectionSetting()
+        .withField("655")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfield("*") //any subfield
+        .withData("fast"));
+
+    MappingParameters mappingParameters = new MappingParameters()
+      .withMarcFieldProtectionSettings(protectionSettings);
+    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
+  }
+
+  @Test
+  public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsProtectedAndIncomingFieldIsSameWithMatchesSubfieldProtectionSettings() {
+    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00200nam  22000731a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+
+    List<MarcFieldProtectionSetting> protectionSettings = List.of(
+      new MarcFieldProtectionSetting()
+        .withField("655")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfield("2") //selected subfield
+        .withData("fast"));
+
+    MappingParameters mappingParameters = new MappingParameters()
+      .withMarcFieldProtectionSettings(protectionSettings);
+    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
+  }
+
+  @Test
+  public void shouldNotRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsNotProtectedAndIncomingFieldIsSameWithNotMatchesSubfieldProtectionSettings() {
+    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+    String expectedParsedContent = "{\"leader\":\"00152nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
+
+    List<MarcFieldProtectionSetting> protectionSettings = List.of(
+      new MarcFieldProtectionSetting()
+        .withField("655")
+        .withIndicator1("*")
+        .withIndicator2("*")
+        .withSubfield("2") //selected subfield
+        .withData("notfast"));
+
+    MappingParameters mappingParameters = new MappingParameters()
+      .withMarcFieldProtectionSettings(protectionSettings);
+    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
+  }
+
+  @Test
   public void shouldRetainExistingRepeatableFieldWhenExistingIsProtectedAndHasNoIncomingFieldWithSameTag() {
     // 950 is repeatable field
     String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"}]}";

--- a/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
+++ b/src/test/java/org/folio/processing/mapping/mapper/writer/marc/MarcRecordModifierTest.java
@@ -2034,25 +2034,6 @@ public class MarcRecordModifierTest {
   }
 
   @Test
-  public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsNotProtectedAndIncomingFieldIsNotSameWithMultipleSubfieldProtectionSettings() {
-    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00152nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-
-    List<MarcFieldProtectionSetting> protectionSettings = List.of(
-      new MarcFieldProtectionSetting()
-        .withField("655")
-        .withIndicator1("*")
-        .withIndicator2("*")
-        .withSubfield("*")
-        .withData("notfast"));
-
-    MappingParameters mappingParameters = new MappingParameters()
-      .withMarcFieldProtectionSettings(protectionSettings);
-    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
-  }
-
-  @Test
   public void shouldRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsProtectedAndSomeIncomingFieldIsSameWithMatchesMultipleSubfieldProtectionSettings() {
     String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
     String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
@@ -2084,25 +2065,6 @@ public class MarcRecordModifierTest {
         .withIndicator2("*")
         .withSubfield("2") //selected subfield
         .withData("fast"));
-
-    MappingParameters mappingParameters = new MappingParameters()
-      .withMarcFieldProtectionSettings(protectionSettings);
-    testUpdateRecord(incomingParsedContent, existingParsedContent, expectedParsedContent, mappingParameters);
-  }
-
-  @Test
-  public void shouldNotRetainExistingRepeatableDataFieldAndAddIncomingWhenExistingIsNotProtectedAndIncomingFieldIsSameWithNotMatchesSubfieldProtectionSettings() {
-    String incomingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-    String existingParsedContent = "{\"leader\":\"00129nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs0.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst014\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-    String expectedParsedContent = "{\"leader\":\"00152nam  22000611a 4500\",\"fields\":[{\"001\":\"ybp7406411\"},{\"655\":{\"subfields\":[{\"a\":\"Catalogs1.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst015\"}],\"ind1\":\" \",\"ind2\":\"7\"}},{\"655\":{\"subfields\":[{\"a\":\"Periodicals.\"},{\"2\":\"fast\"},{\"0\":\"(OCoLC)fst01411641\"}],\"ind1\":\" \",\"ind2\":\"7\"}}]}";
-
-    List<MarcFieldProtectionSetting> protectionSettings = List.of(
-      new MarcFieldProtectionSetting()
-        .withField("655")
-        .withIndicator1("*")
-        .withIndicator2("*")
-        .withSubfield("2") //selected subfield
-        .withData("notfast"));
 
     MappingParameters mappingParameters = new MappingParameters()
       .withMarcFieldProtectionSettings(protectionSettings);

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,18 @@
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = INFO
+
+appenders = console
+
+packages = org.folio.okapi.common.logging
+
+appender.console.type = Console
+appender.console.name = STDOUT
+
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5p %-20.20C{1} [%reqId] %m%n
+
+rootLogger.level = INFO
+rootLogger.appenderRefs = INFO
+rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
## Purpose
This issue was reproduced when the "Subfield" filed in "MARC field protection" equals "*".

## Approach
The value of all Subfields will be checked for equality with the specified value

## Learning
[MODDATAIMP-1189](https://folio-org.atlassian.net/browse/MODDATAIMP-1189)