### PR TITLE
MODDICORE-455: Disable dependency reduced pom in maven-shade-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,7 @@
             </goals>
             <configuration>
               <artifactSet />
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <outputFile>${project.build.directory}/${project.artifactId}-fat.jar</outputFile>
             </configuration>
           </execution>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDICORE-455

The software library data-import-processing-core must ship will all required dependencies, therefore maven-shade-plugin must not create a dependency reduced pom.

## Purpose
Release a pom.xml will all required dependencies.

## Approach
Disable dependency reduced pom.

#### TODOS and Open Questions
- [x] Check logging.