### PR TITLE
MODDICORE-457 Enhance CQL Query Gen for Performance During Identifier Matching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>data-import-processing-core</artifactId>
-  <version>4.5.0-OK-SNAPSHOT</version>
+  <version>4.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>data-import-processing-core</name>
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>data-import-processing-core</artifactId>
-  <version>4.5.0-SNAPSHOT</version>
+  <version>4.5.0-SNAPSHOT-ok</version>
   <packaging>jar</packaging>
   <name>data-import-processing-core</name>
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>data-import-processing-core</artifactId>
-  <version>4.5.0-SNAPSHOT-ok</version>
+  <version>4.5.0-OK-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>data-import-processing-core</name>
   <organization>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODDICORE-457

Per @okolawole-ebsco 

## Purpose
Data import job fails with timeout errors when matching MARC records against existing instances by identifiers. Investigation reveals:
Current Generated SQL Structure: 
   ```
WHERE (get_tsvector(...) @@ tsquery_phrase('"identifierTypeId":"439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"')) 
   AND ((get_tsvector(...) @@ tsquery_phrase('"value":"(OCoLC)on1349275037"')) 
   OR (get_tsvector(...) @@ tsquery_phrase('"value":"(OCoLC)1349275037"')))
```
Postgres's query planner cannot determine that filtering by `value` first would be more selective since it's using full-text search. The current CQL structure generates SQL that encourages Postgres to use the less selective `identifierTypeId` filter as the primary index condition.

There is also an incorrect edge case where the query is looking for an instance that has a specific identifier type id and some oclc number. It is not looking for a oclc number of a specific identifier type id. The query would match for an instance with the following identifiers:
```
{
  "identifiers": [
    {"identifierTypeId": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef", "value": "completely-different"},
    {"identifierTypeId": "some-other-type", "value": "(OCoLC)1349275037"}
  ]
}
```

## Approach

Restructure the CQL generation in `LoadQueryBuilder` to produce queries that encourage PostgreSQL to use the more selective value filter first. The new structure generates individual AND conditions for each value paired with the identifier type:
```
WHERE ((get_tsvector(...) @@ tsquery_phrase('"value":"(OCoLC)on1349275037"') 
        AND get_tsvector(...) @@ tsquery_phrase('"identifierTypeId":"439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"'))
    OR (get_tsvector(...) @@ tsquery_phrase('"value":"(OCoLC)1349275037"') 
        AND get_tsvector(...) @@ tsquery_phrase('"identifierTypeId":"439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"')))

```