### PR TITLE
MODDICORE-459 - Fill in permissions header during event sending 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2025-mm-dd v4.5.0-SNAPSHOT
+* [MODSOURCE-919](https://folio-org.atlassian.net/browse/MODSOURCE-919) Fill in permissions header during event sending to Kafka
+
 ## 2025-03-07 v4.4.0
 * [MODDICORE-433](https://folio-org.atlassian.net/browse/MODDICORE-433) Add userId to event header and allow to send events with null token
 * [MODDICORE-432](https://folio-org.atlassian.net/browse/MODDICORE-432) Vendor details are empty with code that contains brackets during order creation

--- a/src/main/java/org/folio/processing/events/services/publisher/KafkaEventPublisher.java
+++ b/src/main/java/org/folio/processing/events/services/publisher/KafkaEventPublisher.java
@@ -33,6 +33,7 @@ public class KafkaEventPublisher implements EventPublisher, AutoCloseable {
   private static final Logger LOGGER = LogManager.getLogger(KafkaEventPublisher.class);
   public static final String RECORD_ID_HEADER = "recordId";
   public static final String CHUNK_ID_HEADER = "chunkId";
+  static final String PERMISSIONS_HEADER = "X-Okapi-Permissions";
   private static final String JOB_EXECUTION_ID_HEADER = "jobExecutionId";
 
   private static final AtomicLong indexer = new AtomicLong();
@@ -109,6 +110,8 @@ public class KafkaEventPublisher implements EventPublisher, AutoCloseable {
     List<KafkaHeader> headers = new ArrayList<>();
     Optional.ofNullable(eventPayload.getToken())
       .ifPresent(token -> headers.add(KafkaHeader.header(OKAPI_TOKEN_HEADER, token)));
+    Optional.ofNullable(eventPayload.getContext().get(PERMISSIONS_HEADER))
+      .ifPresent(permissions -> headers.add(KafkaHeader.header(PERMISSIONS_HEADER, permissions)));
     Optional.ofNullable(eventPayload.getContext())
       .map(it -> it.get(USER_ID_HEADER))
       .ifPresent(userId -> headers.add(KafkaHeader.header(USER_ID_HEADER, userId)));


### PR DESCRIPTION
## Purpose
to restrict data import update action from a member tenant for a record/instance located on a central tenant


## Learning
[MODDICORE-459](https://issues.folio.org/browse/MODDICORE-459)