### PR TITLE
MODDICORE-500: Enables automatic resolution of authority identifier types by code during data mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * [MODSOURCE-919](https://folio-org.atlassian.net/browse/MODSOURCE-919) Fill in permissions header during event sending to Kafka
 * [MODDICORE-464](https://folio-org.atlassian.net/browse/MODDICORE-464) Add links, linking rules setter to MarcBibRecordModifier
 * [MODDICORE-468](https://folio-org.atlassian.net/browse/MODDICORE-468) Upgrade to Vert.x v5.0 and RMB v36.0.0
+* [MODDICORE-500](https://folio-org.atlassian.net/browse/MODDICORE-500) Enables automatic resolution of authority identifier types by code during data mapping
 
 ## 2025-03-07 v4.4.0
 * [MODDICORE-433](https://folio-org.atlassian.net/browse/MODDICORE-433) Add userId to event header and allow to send events with null token

--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,7 @@
                 <path>${basedir}/ramls/authority.json</path>
                 <path>${basedir}/ramls/authorityExtended.json</path>
                 <path>${basedir}/ramls/settings/alternativetitletypes.json</path>
+                <path>${basedir}/ramls/settings/authorityidentifiertypes.json</path>
                 <path>${basedir}/ramls/settings/classificationtypes.json</path>
                 <path>${basedir}/ramls/settings/contributornametypes.json</path>
                 <path>${basedir}/ramls/settings/contributortypes.json</path>

--- a/ramls/settings/authorityidentifiertype.json
+++ b/ramls/settings/authorityidentifiertype.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An authority identifier type",
+  "javaType": "org.folio.AuthorityIdentifierType",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "name": {
+      "description": "label for the identifier type",
+      "type": "string"
+    },
+    "code": {
+      "description": "code for the identifier type",
+      "type": "string"
+    },
+    "source": {
+      "type": "string",
+      "description": "label indicating where the identifier type entry originates from, i.e. 'folio' or 'local'"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../raml-storage/raml-util/schemas/metadata.schema",
+      "readonly": true
+     }
+  },
+  "additionalProperties": true,
+  "required": [
+    "name"
+  ]
+}

--- a/ramls/settings/authorityidentifiertypes.json
+++ b/ramls/settings/authorityidentifiertypes.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of authority identifier types",
+  "type": "object",
+  "properties": {
+    "identifierTypes": {
+      "description": "List of identifier types",
+      "id": "authorityIdentifierType",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "authorityidentifiertype.json"
+      }
+    },
+    "totalRecords": {
+      "description": "Estimated or exact total number of records",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "identifierTypes",
+    "totalRecords"
+  ]
+}

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/functions/NormalizationFunction.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang.StringUtils;
 import org.folio.AlternativeTitleType;
+import org.folio.AuthorityIdentifierType;
 import org.folio.AuthorityNoteType;
 import org.folio.CallNumberType;
 import org.folio.ClassificationType;
@@ -509,6 +510,24 @@ public enum NormalizationFunction implements Function<RuleExecutionContext, Stri
         .filter(subjectType -> subjectType.getName().trim().equalsIgnoreCase(typeName))
         .findFirst()
         .map(SubjectType::getId)
+        .orElse(StringUtils.EMPTY);
+    }
+  },
+
+  SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE() {
+    private static final String CODE_PARAMETER = "code";
+
+    @Override
+    public String apply(RuleExecutionContext context) {
+      String typeCode = context.getRuleParameter().getString(CODE_PARAMETER);
+      List<AuthorityIdentifierType> identifierTypes = context.getMappingParameters().getAuthorityIdentifierTypes();
+      if (identifierTypes == null || typeCode == null) {
+        return STUB_FIELD_TYPE_ID;
+      }
+      return identifierTypes.stream()
+        .filter(identifierType -> identifierType.getCode().trim().equalsIgnoreCase(typeCode))
+        .findFirst()
+        .map(AuthorityIdentifierType::getId)
         .orElse(StringUtils.EMPTY);
     }
   },

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
@@ -7,7 +7,6 @@ import org.folio.AlternativeTitleType;
 import org.folio.AuthorityIdentifierType;
 import org.folio.AuthorityNoteType;
 import org.folio.AuthoritySourceFile;
-import org.folio.Authorityidentifiertypes;
 import org.folio.CallNumberType;
 import org.folio.ClassificationType;
 import org.folio.ContributorNameType;

--- a/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
+++ b/src/main/java/org/folio/processing/mapping/defaultmapper/processor/parameters/MappingParameters.java
@@ -4,8 +4,10 @@ import org.apache.commons.collections4.list.UnmodifiableList;
 import org.folio.AcquisitionMethod;
 import org.folio.AcquisitionsUnit;
 import org.folio.AlternativeTitleType;
+import org.folio.AuthorityIdentifierType;
 import org.folio.AuthorityNoteType;
 import org.folio.AuthoritySourceFile;
+import org.folio.Authorityidentifiertypes;
 import org.folio.CallNumberType;
 import org.folio.ClassificationType;
 import org.folio.ContributorNameType;
@@ -75,6 +77,7 @@ public class MappingParameters {
   private List<ItemNoteType> itemNoteTypes = new ArrayList<>();
   private List<MarcFieldProtectionSetting> marcFieldProtectionSettings = new ArrayList<>();
   private String tenantConfigurationZone;
+  private List<AuthorityIdentifierType> authorityIdentifierTypes;
   private List<AuthorityNoteType> authorityNoteTypes;
   private List<AuthoritySourceFile> authoritySourceFiles;
   private List<SubjectSource> subjectSources;
@@ -590,6 +593,19 @@ public class MappingParameters {
 
   public MappingParameters withTenantConfigurationAddresses(List<String> tenantConfigurationAddresses) {
     this.tenantConfigurationAddresses = tenantConfigurationAddresses;
+    return this;
+  }
+
+  public List<AuthorityIdentifierType> getAuthorityIdentifierTypes() {
+    return authorityIdentifierTypes;
+  }
+
+  public void setAuthorityIdentifierTypes(List<AuthorityIdentifierType> authorityIdentifierTypes) {
+    this.authorityIdentifierTypes = authorityIdentifierTypes;
+  }
+
+  public MappingParameters withAuthorityIdentifierTypes(List<AuthorityIdentifierType> authorityIdentifierTypes) {
+    this.authorityIdentifierTypes = new UnmodifiableList<>(authorityIdentifierTypes);
     return this;
   }
 }

--- a/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
+++ b/src/test/java/org/folio/processing/mapping/functions/NormalizationFunctionTest.java
@@ -3,6 +3,7 @@ package org.folio.processing.mapping.functions;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.AuthorityIdentifierType;
 import org.folio.AuthorityNoteType;
 import org.folio.ClassificationType;
 import org.folio.InstanceDateType;
@@ -630,6 +631,24 @@ public class NormalizationFunctionTest {
     String actualContributorNameTypeId = runFunction("set_contributor_name_type_id", context);
     // then
     assertEquals(STUB_FIELD_TYPE_ID, actualContributorNameTypeId);
+  }
+
+  @Test
+  public void SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE_shouldReturnExpectedResult() {
+    // given
+    String expectedIdentifierTypeId = UUID.randomUUID().toString();
+    var identifierType = new AuthorityIdentifierType()
+      .withId(expectedIdentifierTypeId)
+      .withCode("lccn")
+      .withName("LCCN");
+    RuleExecutionContext context = new RuleExecutionContext();
+    context.setMappingParameters(new MappingParameters()
+      .withAuthorityIdentifierTypes(Collections.singletonList(identifierType)));
+    context.setRuleParameter(new JsonObject().put("code", "lccn"));
+    // when
+    String actualIdentifierTypeId = runFunction("set_authority_identifier_type_id_by_code", context);
+    // then
+    assertEquals(expectedIdentifierTypeId, actualIdentifierTypeId);
   }
 
   @Test

--- a/user-story-authority-identifier-type-mapping.md
+++ b/user-story-authority-identifier-type-mapping.md
@@ -1,0 +1,98 @@
+## Purpose/Overview
+
+As a cataloger importing MARC Authority records,
+I want the system to resolve authority identifier types by code during data mapping,
+So that identifier type IDs are automatically populated based on the identifier type code, enabling accurate and efficient authority record imports.
+
+Currently, the data-import-processing-core module supports resolving various reference data types (e.g., classification types, contributor types) during MARC-to-FOLIO mapping. However, there is no support for resolving **Authority Identifier Types** by code. This means authority identifiers cannot be automatically matched to their corresponding type IDs during import, requiring manual intervention or causing incomplete records.
+
+### Technical Approach
+
+- Define JSON schemas for `AuthorityIdentifierType` (single object) and `Authorityidentifiertypes` (collection) under `ramls/settings/`.
+- Register the collection schema in `pom.xml` for Java POJO generation via the `jsonschema2pojo` Maven plugin.
+- Extend `MappingParameters` with a new `authorityIdentifierTypes` field (getter, setter, fluent builder).
+- Add a new `SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE` normalization function that looks up an identifier type ID by matching the `code` parameter (case-insensitive, trimmed).
+
+---
+
+## Requirements/Scope
+
+### Functional Requirements
+1. A new JSON schema `authorityidentifiertype.json` shall define the structure of an authority identifier type with `id`, `name`, `code`, `source`, and `metadata` properties.
+2. A collection schema `authorityidentifiertypes.json` shall define a paginated list of authority identifier types.
+3. Java POJOs (`AuthorityIdentifierType`, `Authorityidentifiertypes`) shall be generated from these schemas at build time.
+4. `MappingParameters` shall support storing and retrieving a list of `AuthorityIdentifierType` objects.
+5. A new normalization function `SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE` shall resolve an authority identifier type ID by matching the `code` rule parameter against the list of authority identifier types in mapping parameters.
+6. Code matching shall be case-insensitive and shall trim whitespace from stored codes.
+7. If no matching identifier type is found, the function shall return an empty string.
+8. If the identifier types list or the code parameter is null, the function shall return the `STUB_FIELD_TYPE_ID` constant.
+
+---
+
+## Acceptance Criteria
+
+**AC1: Identifier type resolved by code**
+- Given mapping parameters contain an authority identifier type with code "lccn" and a known ID
+  When the `SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE` function is invoked with rule parameter `{"code": "lccn"}`
+  Then the function returns the matching identifier type's ID
+
+**AC2: Case-insensitive matching**
+- Given mapping parameters contain an authority identifier type with code "LCCN"
+  When the function is invoked with rule parameter `{"code": "lccn"}`
+  Then the function returns the matching identifier type's ID
+
+**AC3: Whitespace-trimmed matching**
+- Given mapping parameters contain an authority identifier type with code " lccn "
+  When the function is invoked with rule parameter `{"code": "lccn"}`
+  Then the function returns the matching identifier type's ID
+
+**AC4: No match returns empty string**
+- Given mapping parameters contain authority identifier types but none with code "nonexistent"
+  When the function is invoked with rule parameter `{"code": "nonexistent"}`
+  Then the function returns an empty string
+
+**AC5: Null identifier types returns stub ID**
+- Given mapping parameters have a null authority identifier types list
+  When the function is invoked with any code parameter
+  Then the function returns `STUB_FIELD_TYPE_ID`
+
+**AC6: Null code parameter returns stub ID**
+- Given mapping parameters contain valid authority identifier types
+  When the function is invoked with a null code parameter
+  Then the function returns `STUB_FIELD_TYPE_ID`
+
+**AC7: JSON schemas generate valid POJOs**
+- Given the `authorityidentifiertype.json` and `authorityidentifiertypes.json` schemas are defined
+  When the project is built with Maven
+  Then `AuthorityIdentifierType` and `Authorityidentifiertypes` Java classes are generated with correct fields and accessors
+
+---
+
+## Testing Guidance
+
+### Manual Testing
+
+**Scenario 1: Verify identifier type resolution during MARC Authority import**
+1. Configure the system with authority identifier types (e.g., "lccn", "isbn").
+2. Import a MARC Authority record that contains an identifier field mapped with the `SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE` function.
+3. Verify the resulting Authority record has the correct identifier type ID populated.
+
+**Scenario 2: Verify behavior with unknown code**
+1. Import a MARC Authority record with an identifier code that does not match any configured authority identifier type.
+2. Verify the identifier type ID field is empty (not populated with an incorrect value).
+
+**Scenario 3: Verify build generates schemas**
+1. Run `mvn clean install`.
+2. Verify that `AuthorityIdentifierType.java` and `Authorityidentifiertypes.java` are generated in the `target/` directory.
+3. Confirm the generated classes include `id`, `name`, `code`, `source`, and `metadata` fields with appropriate getters/setters.
+
+**Note:** Unit test specs, integration test code, and test data details belong in the implementation plan, not here.
+
+---
+
+## Related Links
+- Schema: `ramls/settings/authorityidentifiertype.json`
+- Collection schema: `ramls/settings/authorityidentifiertypes.json`
+- Normalization function: `NormalizationFunction.java`
+- Mapping parameters: `MappingParameters.java`
+- Unit test: `NormalizationFunctionTest.java`


### PR DESCRIPTION
## Purpose
Enables automatic resolution of authority identifier types by code during data mapping

## Approach

- Define JSON schemas for AuthorityIdentifierType (single object) and Authorityidentifiertypes (collection) under ramls/settings/.
- Register the collection schema in pom.xml for Java POJO generation via the jsonschema2pojo Maven plugin.
- Extend MappingParameters with a new authorityIdentifierTypes field (getter, setter, fluent builder).
- Add a new SET_AUTHORITY_IDENTIFIER_TYPE_ID_BY_CODE normalization function that looks up an identifier type ID by matching the code parameter (case-insensitive, trimmed).
